### PR TITLE
APT-1513: APR calculation fix

### DIFF
--- a/src/components/stakingPoolCard.tsx
+++ b/src/components/stakingPoolCard.tsx
@@ -86,7 +86,7 @@ const StakingPoolCard: React.FC<StakingPoolCardProps> = ({
                           : 'text-gray4'
                       }`}
                     >
-                      VP {stakingPoolData.data.votingPower * 100}%
+                      VP {(stakingPoolData.data.votingPower * 100).toPrecision(3)}%
                     </div>
                   ) : (
                     <>

--- a/src/misc/stakingPoolsConfig.ts
+++ b/src/misc/stakingPoolsConfig.ts
@@ -91,8 +91,10 @@ async function fetchDelegatorDataFromNetwork(definition: StakingPoolDefinition, 
 
     const zilToTokenRate = 1 / parseFloat(formatUnits(zilToTokenRateWei, 18));
 
-    const commission = Number((commissionNumerator * 100n) / commissionDenominator) / 100;
-    const votingPower = Number(((delegatorStake * 100n) / depositTotalStake)) / 100;
+    const bigingDivisionPrecision = 1000000n;
+
+    const commission = Number((commissionNumerator * bigingDivisionPrecision) / commissionDenominator) / Number(bigingDivisionPrecision);
+    const votingPower = Number(((delegatorStake * bigingDivisionPrecision) / depositTotalStake)) / Number(bigingDivisionPrecision);
     const rewardsPerYearInZil = 51000 * 24 * 365;
 
     const delegatorYearReward = votingPower * rewardsPerYearInZil;

--- a/src/misc/stakingPoolsConfig.ts
+++ b/src/misc/stakingPoolsConfig.ts
@@ -91,10 +91,10 @@ async function fetchDelegatorDataFromNetwork(definition: StakingPoolDefinition, 
 
     const zilToTokenRate = 1 / parseFloat(formatUnits(zilToTokenRateWei, 18));
 
-    const bigingDivisionPrecision = 1000000n;
+    const bigintDivisionPrecision = 1000000n;
 
-    const commission = Number((commissionNumerator * bigingDivisionPrecision) / commissionDenominator) / Number(bigingDivisionPrecision);
-    const votingPower = Number(((delegatorStake * bigingDivisionPrecision) / depositTotalStake)) / Number(bigingDivisionPrecision);
+    const commission = Number((commissionNumerator * bigintDivisionPrecision) / commissionDenominator) / Number(bigintDivisionPrecision);
+    const votingPower = Number(((delegatorStake * bigintDivisionPrecision) / depositTotalStake)) / Number(bigintDivisionPrecision);
     const rewardsPerYearInZil = 51000 * 24 * 365;
 
     const delegatorYearReward = votingPower * rewardsPerYearInZil;


### PR DESCRIPTION
# Description

Increasing the `bigint` division precision was required to get close to the correct number.

# Testing

Numbers on the app are the same as expected from offline calculation.