### PR TITLE
APT-1508: New DNS names

### DIFF
--- a/render_config_devnet.yaml
+++ b/render_config_devnet.yaml
@@ -1,0 +1,40 @@
+project_id: prj-d-staging-6zj2hygf
+bastion_instance_name: vm-d-staging-bastion-ase1
+bastion_instance_zone: asia-southeast1-a
+region: asia-southeast1
+
+k8s_clusters:
+  staging:
+    project_id: "prj-d-staging-6zj2hygf"
+    name: gke-d-staging-01-ase1
+
+registry: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private
+
+dbs_to_instances: []
+
+apps_to_clusters:
+  - name_re: main/zq2-staking/zq2-staking-frontend
+    cluster: staging
+    dns_name: stake.zq2-devnet.zilliqa.com
+    healthcheck:
+      request_path: /api/health
+    image_name: zq2-staking-frontend
+    namespace: zq2-staking-devnet
+    pipeline:
+      dockerfile_path: images/frontend/Dockerfile
+      context: .
+    replicas: 1
+    env_vars:
+      - name: ZQ2_STAKING_CHAIN_ID
+        value: 33469
+    pod_limits:
+      cpu: 200m
+      memory: 200Mi
+    pod_requests:
+      cpu: 100m
+      memory: 100Mi
+
+secrets:
+  zq2_staking:
+    wallet_connect_api_key:
+      _op: "op://prj-d-staging/zq2-staking/WALLET_CONNECT_API_KEY"

--- a/render_config_protomainnet.yaml
+++ b/render_config_protomainnet.yaml
@@ -15,11 +15,11 @@ dbs_to_instances: []
 apps_to_clusters:
   - name_re: main/zq2-staking/zq2-staking-frontend
     cluster: production
-    dns_name: stake.zq2-protomainet.zilliqa.com
+    dns_name: stake.zq2-protomainnet.zilliqa.com
     healthcheck:
       request_path: /api/health
     image_name: zq2-staking-frontend
-    namespace: zq2-staking-protomainet
+    namespace: zq2-staking-protomainnet
     pipeline:
       dockerfile_path: images/frontend/Dockerfile
       context: .

--- a/render_config_protomainnet.yaml
+++ b/render_config_protomainnet.yaml
@@ -1,32 +1,32 @@
-project_id: prj-d-staging-6zj2hygf
-bastion_instance_name: vm-d-staging-bastion-ase1
+project_id: prj-p-prod-apps-3cidxzuc
+bastion_instance_name: vm-p-prod-apps-bastion-ase1
 bastion_instance_zone: asia-southeast1-a
 region: asia-southeast1
 
 k8s_clusters:
-  staging:
-    project_id: "prj-d-staging-6zj2hygf"
-    name: gke-d-staging-01-ase1
+  production:
+    project_id: "prj-p-prod-apps-3cidxzuc"
+    name: gke-p-prod-apps-01-ase1
 
-registry: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private
+registry: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private
 
 dbs_to_instances: []
 
 apps_to_clusters:
   - name_re: main/zq2-staking/zq2-staking-frontend
-    cluster: staging
-    dns_name: zq2-staking.zilstg.dev
+    cluster: production
+    dns_name: stake.zq2-protomainet.zilliqa.com
     healthcheck:
       request_path: /api/health
     image_name: zq2-staking-frontend
-    namespace: zq2-staking-stg
+    namespace: zq2-staking-protomainet
     pipeline:
       dockerfile_path: images/frontend/Dockerfile
       context: .
     replicas: 1
     env_vars:
       - name: ZQ2_STAKING_CHAIN_ID
-        value: 33103
+        value: 32770
     pod_limits:
       cpu: 200m
       memory: 200Mi

--- a/render_config_prototestnet.yaml
+++ b/render_config_prototestnet.yaml
@@ -1,0 +1,40 @@
+project_id: prj-d-staging-6zj2hygf
+bastion_instance_name: vm-d-staging-bastion-ase1
+bastion_instance_zone: asia-southeast1-a
+region: asia-southeast1
+
+k8s_clusters:
+  staging:
+    project_id: "prj-d-staging-6zj2hygf"
+    name: gke-d-staging-01-ase1
+
+registry: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private
+
+dbs_to_instances: []
+
+apps_to_clusters:
+  - name_re: main/zq2-staking/zq2-staking-frontend
+    cluster: staging
+    dns_name: stake.zq2-prototestnet.zilliqa.com
+    healthcheck:
+      request_path: /api/health
+    image_name: zq2-staking-frontend
+    namespace: zq2-staking-prototestnet
+    pipeline:
+      dockerfile_path: images/frontend/Dockerfile
+      context: .
+    replicas: 1
+    env_vars:
+      - name: ZQ2_STAKING_CHAIN_ID
+        value: 33103
+    pod_limits:
+      cpu: 200m
+      memory: 200Mi
+    pod_requests:
+      cpu: 100m
+      memory: 100Mi
+
+secrets:
+  zq2_staking:
+    wallet_connect_api_key:
+      _op: "op://prj-d-staging/zq2-staking/WALLET_CONNECT_API_KEY"

--- a/render_config_prototestnet.yaml
+++ b/render_config_prototestnet.yaml
@@ -37,4 +37,4 @@ apps_to_clusters:
 secrets:
   zq2_staking:
     wallet_connect_api_key:
-      _op: "op://prj-d-staging/zq2-staking/WALLET_CONNECT_API_KEY"
+      _op: "op://prj-p-prod-apps/zq2-staking/WALLET_CONNECT_API_KEY"

--- a/src/misc/chainConfig.ts
+++ b/src/misc/chainConfig.ts
@@ -38,6 +38,23 @@ export const CHAIN_ZQ2_PROTOTESTNET = defineChain({
   },
 })
 
+export const CHAIN_ZQ2_PROTOMAINNET = defineChain({
+  id: 32770,
+  name: 'Zq2 ProtoMainnet',
+  nativeCurrency: { name: 'ZIL', symbol: 'ZIL', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://api.zq2-protomainnet.zilliqa.com'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Otterscan',
+      url: 'https://explorer.zq2-protomainnet.zilliqa.com',
+    },
+  },
+})
+
 export const CHAIN_ZQ2_DOCKERCOMPOSE = defineChain({
   id: 87362,
   name: 'Zq2 Dockercompose',
@@ -100,6 +117,7 @@ export function getChain(chainId: number) {
   const chain = [
     CHAIN_ZQ2_DEVNET,
     CHAIN_ZQ2_PROTOTESTNET,
+    CHAIN_ZQ2_PROTOMAINNET,
     CHAIN_ZQ2_DOCKERCOMPOSE,
     MOCK_CHAIN,
   ].find(

--- a/src/misc/stakingPoolsConfig.ts
+++ b/src/misc/stakingPoolsConfig.ts
@@ -1,5 +1,5 @@
 import { Address, erc20Abi, formatUnits, parseUnits } from "viem";
-import { CHAIN_ZQ2_PROTOTESTNET, CHAIN_ZQ2_DOCKERCOMPOSE, getViemClient, MOCK_CHAIN, CHAIN_ZQ2_DEVNET } from "./chainConfig";
+import { CHAIN_ZQ2_PROTOTESTNET, CHAIN_ZQ2_DOCKERCOMPOSE, getViemClient, MOCK_CHAIN, CHAIN_ZQ2_DEVNET, CHAIN_ZQ2_PROTOMAINNET } from "./chainConfig";
 import { readContract } from "viem/actions";
 import { delegatorAbi, depositAbi } from "./stakingAbis";
 
@@ -288,5 +288,8 @@ export const stakingPoolsConfigForChainId: Record<string, Array<StakingPoolConfi
       },
       delegatorDataProvider: fetchDelegatorDataFromNetwork.bind(null)
     },
+  ],
+  [CHAIN_ZQ2_PROTOMAINNET.id]: [
+
   ]
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -198,7 +198,7 @@ const HomePage = () => {
                 Back
               </Button></div>
             ) }
-            <div className={`${stakingPoolForView ? "xs:w-1/2" : "w-full"}`}>
+            <div className={`flex items-center justify-center h-[58.79px] bg-[#0e76fd] rounded-lg ${stakingPoolForView ? "w-1/2" : "w-full"}`}>
             {connectWallet}
            </div>
             </>


### PR DESCRIPTION
# Description

- App mvoed to new DNS names under `zilliqa.com`. One app deployment config per devnet, prototestnet, and protomainnet. This is a counterpart for https://github.com/Zilliqa/devops/pull/1284
- RainbowKit connect button now is properly positioned in the bottom mobile navigation panel  

# Testing

App works with devnet when running locally.