### PR TITLE
APT-1682: Scaffold for non-liquid staking added

### DIFF
--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -13,6 +13,7 @@ import { formatUnits, parseEther } from "viem"
 import { StakingOperations } from "@/contexts/stakingOperations"
 import { AppConfigStorage } from "@/contexts/appConfigStorage"
 import Link from "next/link"
+import { StakingPoolType } from "@/misc/stakingPoolsConfig"
 
 const StakingCalculator: React.FC = () => {
   const { appConfig } = AppConfigStorage.useContainer()
@@ -83,6 +84,10 @@ const StakingCalculator: React.FC = () => {
     setZilToStake(`${formatUnits(zilAvailable || 0n, 18)}`)
   }
 
+  const isPoolLiquid = () =>
+    stakingPoolForView?.stakingPool.definition.poolType ===
+    StakingPoolType.LIQUID
+
   return (
     stakingPoolForView && (
       <>
@@ -105,17 +110,21 @@ const StakingCalculator: React.FC = () => {
               <span className="flex items-center whitespace-nowrap ">
                 {stakingPoolForView!.stakingPool.data ? (
                   <>
-                    <span className="body2-medium">
-                      ~
-                      {!isNaN(zilToStakeNumber) &&
-                      !isNaN(stakingPoolForView.stakingPool.data.zilToTokenRate)
-                        ? convertZilValueInToken(
-                            zilToStakeNumber,
-                            stakingPoolForView.stakingPool.data.zilToTokenRate
-                          )
-                        : ""}{" "}
-                      {stakingPoolForView.stakingPool.definition.tokenSymbol}{" "}
-                    </span>
+                    {isPoolLiquid() && (
+                      <span className="body2-medium">
+                        ~
+                        {!isNaN(zilToStakeNumber) &&
+                        !isNaN(
+                          stakingPoolForView.stakingPool.data.zilToTokenRate
+                        )
+                          ? convertZilValueInToken(
+                              zilToStakeNumber,
+                              stakingPoolForView.stakingPool.data.zilToTokenRate
+                            )
+                          : ""}{" "}
+                        {stakingPoolForView.stakingPool.definition.tokenSymbol}{" "}
+                      </span>
+                    )}
                     <span className="body2-medium ml-2 text-aqua1">
                       ~
                       {formatPercentage(
@@ -165,12 +174,14 @@ const StakingCalculator: React.FC = () => {
               </div>
             </div>
             <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
-              <div className="flex flex-col xl:flex-row xl:gap-5">
-                <div className="gray-base">Rate</div>
-                {stakingPoolForView!.stakingPool.data && (
-                  <div className="text-gray9">{`1 ZIL = ~${stakingPoolForView.stakingPool.data.zilToTokenRate} ${stakingPoolForView.stakingPool.definition.tokenSymbol}`}</div>
-                )}
-              </div>
+              {isPoolLiquid() && (
+                <div className="flex flex-col xl:flex-row xl:gap-5">
+                  <div className="gray-base">Rate</div>
+                  {stakingPoolForView!.stakingPool.data && (
+                    <div className="text-gray9">{`1 ZIL = ~${stakingPoolForView.stakingPool.data.zilToTokenRate} ${stakingPoolForView.stakingPool.definition.tokenSymbol}`}</div>
+                  )}
+                </div>
+              )}
               <div className="text-gray9 text-aqua1 flex flex-row xl:gap-5">
                 <Tooltip
                   placement="top"

--- a/src/components/stakingPoolDetailsView.tsx
+++ b/src/components/stakingPoolDetailsView.tsx
@@ -2,9 +2,8 @@ import StakingCalculator from "@/components/stakingCalculator"
 import UnstakingCalculator from "@/components/unstakingCalculator"
 import WithdrawZilPanel from "@/components/withdrawUnstakedZilPanel"
 import { WalletConnector } from "@/contexts/walletConnector"
-import { getViemClient } from "@/misc/chainConfig"
 import { formatPercentage, formatUnitsToHumanReadable } from "@/misc/formatting"
-import { StakingPool } from "@/misc/stakingPoolsConfig"
+import { StakingPool, StakingPoolType } from "@/misc/stakingPoolsConfig"
 import {
   UserStakingPoolData,
   UserUnstakingPoolData,
@@ -13,7 +12,6 @@ import { Button } from "antd"
 import { DateTime } from "luxon"
 import { useState } from "react"
 import { useWatchAsset } from "wagmi"
-import { useWalletClient } from "wagmi"
 import Plus from "../assets/svgs/plus.svg"
 import PlusIcon from "../assets/svgs/plus-icon.svg"
 import Image from "next/image"
@@ -53,6 +51,9 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
       <div className="text-gray8 info-label xl:whitespace-nowrap">{title}</div>
     </div>
   )
+
+  const isPoolLiquid = () =>
+    stakingPoolData.definition.poolType === StakingPoolType.LIQUID
 
   const pendingUnstakesValue = userUnstakingPoolData
     ?.filter((item) => item.availableAt > DateTime.now())
@@ -104,36 +105,25 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
           <span className="text-white1 text-48 font-bold mr-6">
             {stakingPoolData.definition.name}
           </span>
-          <span className="text-38 lg:h4 text-black3  font-light">|</span>
-          <span className="body1 lg:h4 text-gray6 ml-6 font-medium">
-            {stakingPoolData.definition.tokenSymbol}
-          </span>
-          <Image
-            onClick={handleClickAaddToken}
-            className="h-[28px] w-[28px] ml-4 cursor-pointer"
-            src={PlusIcon}
-            alt="arrow icon"
-            width={28}
-            height={28}
-          />
+
+          {isPoolLiquid() && (
+            <>
+              <span className="text-38 lg:h4 text-black3  font-light">|</span>
+              <span className="body1 lg:h4 text-gray6 ml-6 font-medium">
+                {stakingPoolData.definition.tokenSymbol}
+              </span>
+
+              <Image
+                onClick={handleClickAaddToken}
+                className="h-[28px] w-[28px] ml-4 cursor-pointer"
+                src={PlusIcon}
+                alt="arrow icon"
+                width={28}
+                height={28}
+              />
+            </>
+          )}
         </div>
-        {/* <div>
-          <Button
-            onClick={handleClickAaddToken}
-            className="btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua group"
-          >
-            <Image
-              className="h-[24px] w-[24px] transform transition-transform ease-out duration-500 group-hover:rotate-180"
-              src={Plus}
-              alt={"arrow icon"}
-              width={24}
-              height={24}
-            />
-            <span className="!hidden sm:!block lg:!hidden xl:!block ">
-              Add Token
-            </span>
-          </Button>
-        </div> */}
       </div>
 
       <div className="bg-grey-gradient py-6 flex flex-col gap-4 px-9.5 rounded-xl">
@@ -185,16 +175,17 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
             stakingPoolData.data &&
               formatPercentage(stakingPoolData.data.commission)
           )}
-          {greyInfoEntry(
-            "",
-            stakingPoolData.data && (
-              <>
-                1 ZIL ~ <br />
-                {stakingPoolData.data.zilToTokenRate.toPrecision(3)}{" "}
-                {stakingPoolData.definition.tokenSymbol}
-              </>
-            )
-          )}
+          {isPoolLiquid() &&
+            greyInfoEntry(
+              "",
+              stakingPoolData.data && (
+                <>
+                  1 ZIL ~ <br />
+                  {stakingPoolData.data.zilToTokenRate.toPrecision(3)}{" "}
+                  {stakingPoolData.definition.tokenSymbol}
+                </>
+              )
+            )}
         </div>
       </div>
       <div className="grid grid-cols-3">

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -11,6 +11,7 @@ import {
 import { formatUnits, parseEther } from "viem"
 import { StakingOperations } from "@/contexts/stakingOperations"
 import { DateTime } from "luxon"
+import { StakingPoolType } from "@/misc/stakingPoolsConfig"
 
 const UnstakingCalculator: React.FC = () => {
   const { stakingPoolForView } = StakingPoolsStorage.useContainer()
@@ -76,6 +77,10 @@ const UnstakingCalculator: React.FC = () => {
     })
   )
 
+  const isPoolLiquid = () =>
+    stakingPoolForView?.stakingPool.definition.poolType ===
+    StakingPoolType.LIQUID
+
   return (
     stakingPoolForView && (
       <div>
@@ -95,23 +100,25 @@ const UnstakingCalculator: React.FC = () => {
                 status={!zilToUnstakeOk ? "error" : undefined}
               />
               <div className="flex items-center ">
-                <span className="body2-medium">
-                  {stakingPoolForView!.stakingPool.data ? (
-                    <>
-                      ~
-                      {formatUnitsToHumanReadable(
-                        convertTokenToZil(
-                          zilInWei,
-                          stakingPoolForView.stakingPool.data.zilToTokenRate
-                        ),
-                        18
-                      )}
-                    </>
-                  ) : (
-                    <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
-                  )}
-                  ZIL
-                </span>
+                {isPoolLiquid() && (
+                  <span className="body2-medium">
+                    {stakingPoolForView!.stakingPool.data ? (
+                      <>
+                        ~
+                        {formatUnitsToHumanReadable(
+                          convertTokenToZil(
+                            zilInWei,
+                            stakingPoolForView.stakingPool.data.zilToTokenRate
+                          ),
+                          18
+                        )}
+                      </>
+                    ) : (
+                      <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
+                    )}
+                    ZIL
+                  </span>
+                )}
                 <span className="body2-medium ml-2 text-aqua1">
                   {unboudingPeriod}
                 </span>
@@ -156,27 +163,31 @@ const UnstakingCalculator: React.FC = () => {
               </div>
             </div>
             <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
-              <div className="flex flex-col xl:flex-row xl:gap-5">
-                <div className="gray-base">Rate</div>
-                <div className="text-gray9">
-                  {stakingPoolForView!.stakingPool.data ? (
-                    <>
-                      1 {stakingPoolForView.stakingPool.definition.tokenSymbol}{" "}
-                      = ~
-                      {formatUnitsToHumanReadable(
-                        convertTokenToZil(
-                          parseEther("1"),
-                          stakingPoolForView.stakingPool.data.zilToTokenRate
-                        ),
-                        18
-                      )}
-                    </>
-                  ) : (
-                    <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
-                  )}
-                  ZIL
+              {isPoolLiquid() && (
+                <div className="flex flex-col xl:flex-row xl:gap-5">
+                  <div className="gray-base">Rate</div>
+                  <div className="text-gray9">
+                    {stakingPoolForView!.stakingPool.data ? (
+                      <>
+                        1{" "}
+                        {stakingPoolForView.stakingPool.definition.tokenSymbol}{" "}
+                        = ~
+                        {formatUnitsToHumanReadable(
+                          convertTokenToZil(
+                            parseEther("1"),
+                            stakingPoolForView.stakingPool.data.zilToTokenRate
+                          ),
+                          18
+                        )}
+                      </>
+                    ) : (
+                      <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
+                    )}
+                    ZIL
+                  </div>
                 </div>
-              </div>
+              )}
+
               <div className="text-gray9 flex flex-row xl:gap-5">
                 <Tooltip
                   placement="top"
@@ -187,6 +198,7 @@ const UnstakingCalculator: React.FC = () => {
                 >
                   <span className="gray-base">APR </span>
                 </Tooltip>
+
                 {stakingPoolForView!.stakingPool.data ? (
                   <>
                     ~

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -22,7 +22,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
   userUnstakingPoolData,
   stakingPoolData,
 }) => {
-  const { claim, isClaimingInProgress, claimCallTxHash } =
+  const { claimUnstake, isClaimingUnstakeInProgress, claimUnstakeCallTxHash } =
     StakingOperations.useContainer()
 
   const { appConfig } = AppConfigStorage.useContainer()
@@ -43,15 +43,15 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
 
   return (
     <div>
-      {claimCallTxHash !== undefined && (
+      {claimUnstakeCallTxHash !== undefined && (
         <div className="text-center gradient-bg-1 py-2 text-gray-500">
           <Link
             rel="noopener noreferrer"
             target="_blank"
-            href={getTxExplorerUrl(claimCallTxHash, appConfig.chainId)}
+            href={getTxExplorerUrl(claimUnstakeCallTxHash, appConfig.chainId)}
             passHref={true}
           >
-            Last staking transaction: {formatAddress(claimCallTxHash)}
+            Last staking transaction: {formatAddress(claimUnstakeCallTxHash)}
           </Link>
         </div>
       )}
@@ -76,8 +76,8 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
               <div className="lg:w-1/3 lg:max-w-[218px]">
                 <Button
                   className="btn-primary-gradient-aqua"
-                  onClick={() => claim(item.address)}
-                  loading={isClaimingInProgress}
+                  onClick={() => claimUnstake(item.address)}
+                  loading={isClaimingUnstakeInProgress}
                 >
                   Claim
                 </Button>

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -7,8 +7,156 @@ import {
   getHumanFormDuration,
 } from "@/misc/formatting"
 import FeedbackIcon from "../assets/svgs/feedback-icon.svg"
+import { StakingPool } from "@/misc/stakingPoolsConfig"
+import {
+  UserNonLiquidStakingPoolRewardData,
+  UserUnstakingPoolData,
+} from "@/misc/walletsConfig"
 import { Button } from "antd"
 import Image from "next/image"
+
+interface UnstakeCardProps {
+  available: boolean
+  unstakeInfo: UserUnstakingPoolData
+  stakingPool: StakingPool
+  selectStakingPoolForView: (stakingPoolId: string | null) => void
+  claimUnstake: (delegatorAddress: string) => void
+}
+
+const UnstakeCard: React.FC<UnstakeCardProps> = ({
+  available,
+  unstakeInfo,
+  stakingPool,
+  selectStakingPoolForView,
+  claimUnstake: claim,
+}) => {
+  return (
+    <div className="flex gap-2.5 lg:w-full max-lg:flex-col">
+      <div className="flex lg:flex-col bg-gradientbg content-center px-3 py-4 lg:px-4 rounded-lg justify-between max-lg:items-center lg:w-2/3">
+        <div className="flex items-center">
+          <Image
+            className="mr-2 lg:mr-2.5"
+            src={stakingPool.definition.iconUrl}
+            alt={`${stakingPool.definition.name} icon`}
+            width={31}
+            height={31}
+          />
+          <div className="body1">{stakingPool.definition.name}</div>
+        </div>
+        <div className="flex lg:mt-3 items-center">
+          <div className="h3-s max-lg:order-2">
+            {stakingPool.data ? (
+              <>
+                {formatUnitsToHumanReadable(
+                  convertTokenToZil(
+                    unstakeInfo.zilAmount,
+                    stakingPool.data!.zilToTokenRate
+                  ),
+                  18
+                )}{" "}
+                ZIL
+              </>
+            ) : (
+              <>
+                <div className="w-[2em] h-[0.75em] animated-gradient" />
+              </>
+            )}
+          </div>
+          <div className="body1-s max-lg:mr-2.5 lg:ml-2.5 max-lg:order-1">
+            {unstakeInfo.zilAmount} {stakingPool.definition.tokenSymbol}
+          </div>
+        </div>
+      </div>
+      <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[218px]">
+        <div className="max-lg:w-1/2">
+          <Button
+            className="btn-primary-gradient-aqua"
+            disabled={!available}
+            onClick={() => claim(unstakeInfo.address)}
+          >
+            {available
+              ? "Claim"
+              : getHumanFormDuration(unstakeInfo.availableAt) + " left"}
+          </Button>
+        </div>
+        <div className="max-lg:w-1/2 lg:mt-2.5">
+          <Button
+            className="btn-primary-white1"
+            onClick={() => selectStakingPoolForView(stakingPool.definition.id)}
+          >
+            View
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface RewardCardProps {
+  stakingPool: StakingPool
+  rewardInfo: UserNonLiquidStakingPoolRewardData
+  selectStakingPoolForView: (stakingPoolId: string | null) => void
+  claimReward: (delegatorAddress: string) => void
+}
+
+const RewardCard: React.FC<RewardCardProps> = ({
+  rewardInfo,
+  stakingPool,
+  selectStakingPoolForView,
+  claimReward,
+}) => {
+  return (
+    <div className="flex gap-2.5 lg:w-full max-lg:flex-col">
+      <div className="flex lg:flex-col bg-gradientbg content-center px-3 py-4 lg:px-4 rounded-lg justify-between max-lg:items-center lg:w-2/3">
+        <div className="flex items-center">
+          <Image
+            className="mr-2 lg:mr-2.5"
+            src={stakingPool.definition.iconUrl}
+            alt={`${stakingPool.definition.name} icon`}
+            width={31}
+            height={31}
+          />
+          <div className="body1">{stakingPool.definition.name}</div>
+          <div>Reward</div>
+        </div>
+        <div className="flex lg:mt-3 items-center">
+          <div className="h3-s max-lg:order-2">
+            {stakingPool.data ? (
+              <>
+                {formatUnitsToHumanReadable(rewardInfo.zilRewardAmount, 18)} ZIL
+              </>
+            ) : (
+              <>
+                <div className="w-[2em] h-[0.75em] animated-gradient" />
+              </>
+            )}
+          </div>
+          <div className="body1-s max-lg:mr-2.5 lg:ml-2.5 max-lg:order-1">
+            {rewardInfo.zilRewardAmount}
+          </div>
+        </div>
+      </div>
+      <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[218px]">
+        <div className="max-lg:w-1/2">
+          <Button
+            className="btn-primary-gradient-aqua"
+            onClick={() => claimReward(stakingPool.definition.address)}
+          >
+            Claim Reward
+          </Button>
+        </div>
+        <div className="max-lg:w-1/2 lg:mt-2.5">
+          <Button
+            className="btn-primary-white1"
+            onClick={() => selectStakingPoolForView(stakingPool.definition.id)}
+          >
+            View
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 const WithdrawZilView: React.FC = () => {
   const {
@@ -16,14 +164,15 @@ const WithdrawZilView: React.FC = () => {
     pendingUnstaking,
     selectStakingPoolForView,
     isUnstakingDataLoading,
+    nonLiquidRewards,
   } = StakingPoolsStorage.useContainer()
 
-  const { claim } = StakingOperations.useContainer()
+  const { claimUnstake, claimReward } = StakingOperations.useContainer()
 
-  const unstakingItems = [
-    ...availableForUnstaking.map((item) => ({ ...item, available: true })),
-    ...pendingUnstaking.map((item) => ({ ...item, available: false })),
-  ]
+  const anyItemsAvailable =
+    availableForUnstaking.length > 0 ||
+    pendingUnstaking.length > 0 ||
+    nonLiquidRewards.length > 0
 
   return (
     <div
@@ -38,81 +187,43 @@ const WithdrawZilView: React.FC = () => {
         </h1>
       </div>
 
-      {unstakingItems.length > 0 ? (
+      {anyItemsAvailable ? (
         <div
           className="grid grid-cols-1 gap-4 lg:gap-5 overflow-y-auto  max-h-[calc(90vh-30vh)]
           scrollbar-thin scrollbar-thumb-gray1 scrollbar-track-gray1 hover:scrollbar-thumb-gray1 lg:pb-10
            pr-2 lg:pr-4
           "
         >
-          {unstakingItems.map((item, claimIdx) => (
-            <div
-              className="flex gap-2.5 lg:w-full max-lg:flex-col bg-aqua-gradient rounded-xl"
+          {availableForUnstaking.map((unstakeClaim, claimIdx) => (
+            <UnstakeCard
               key={claimIdx}
-            >
-              <div className="flex lg:flex-col content-center px-3 py-4 lg:px-4 rounded-lg justify-between max-lg:items-center lg:w-2/3">
-                <div className="flex items-center">
-                  <Image
-                    className="mr-2 lg:mr-2.5"
-                    src={item.stakingPool.definition.iconUrl}
-                    alt={`${item.stakingPool.definition.name} icon`}
-                    width={31}
-                    height={31}
-                  />
-                  <div className="body1">
-                    {item.stakingPool.definition.name}
-                  </div>
-                </div>
-                <div className="flex lg:mt-3 items-center">
-                  <div className="h3-s max-lg:order-2">
-                    {item.stakingPool.data ? (
-                      <>
-                        {formatUnitsToHumanReadable(
-                          convertTokenToZil(
-                            item.unstakeInfo.zilAmount,
-                            item.stakingPool.data!.zilToTokenRate
-                          ),
-                          18
-                        )}{" "}
-                        ZIL
-                      </>
-                    ) : (
-                      <>
-                        <div className="w-[2em] h-[0.75em] animated-gradient" />
-                      </>
-                    )}
-                  </div>
-                  <div className="body1-s max-lg:mr-2.5 lg:ml-2.5 max-lg:order-1">
-                    {item.unstakeInfo.zilAmount}{" "}
-                    {item.stakingPool.definition.tokenSymbol}
-                  </div>
-                </div>
-              </div>
-              <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[218px]">
-                <div className="max-lg:w-1/2">
-                  <Button
-                    className="btn-primary-gradient-grey w-full"
-                    disabled={!item.available}
-                    onClick={() => claim(item.unstakeInfo.address)}
-                  >
-                    {item.available
-                      ? "Claim"
-                      : getHumanFormDuration(item.unstakeInfo.availableAt) +
-                        " left"}
-                  </Button>
-                </div>
-                <div className="max-lg:w-1/2 lg:mt-2.5">
-                  <Button
-                    className="btn-secondary-gradient-grey"
-                    onClick={() =>
-                      selectStakingPoolForView(item.stakingPool.definition.id)
-                    }
-                  >
-                    View
-                  </Button>
-                </div>
-              </div>
-            </div>
+              available={true}
+              stakingPool={unstakeClaim.stakingPool}
+              unstakeInfo={unstakeClaim.unstakeInfo}
+              claimUnstake={claimUnstake}
+              selectStakingPoolForView={selectStakingPoolForView}
+            />
+          ))}
+
+          {nonLiquidRewards.map((reward, rewardIdx) => (
+            <RewardCard
+              key={rewardIdx}
+              rewardInfo={reward.rewardInfo}
+              stakingPool={reward.stakingPool}
+              selectStakingPoolForView={selectStakingPoolForView}
+              claimReward={claimReward}
+            />
+          ))}
+
+          {pendingUnstaking.map((pendingUnstakeClaim, claimIdx) => (
+            <UnstakeCard
+              key={claimIdx + 1000}
+              available={false}
+              stakingPool={pendingUnstakeClaim.stakingPool}
+              unstakeInfo={pendingUnstakeClaim.unstakeInfo}
+              claimUnstake={claimUnstake}
+              selectStakingPoolForView={selectStakingPoolForView}
+            />
           ))}
         </div>
       ) : (

--- a/src/contexts/stakingOperations.tsx
+++ b/src/contexts/stakingOperations.tsx
@@ -162,31 +162,33 @@ const useStakingOperations = () => {
   }, [unstakeCallReceiptStatus])
 
   /**
-   * CLAIMING
+   * CLAIMING UNSTAKE
    */
 
-  const [claimCallTxHash, setClaimCallTxHash] = useState<Address | undefined>(
-    undefined
-  )
-  const [preparingClaimTx, setPreparingClaimTx] = useState(false)
+  const [claimUnstakeCallTxHash, setClaimUnstakeCallTxHash] = useState<
+    Address | undefined
+  >(undefined)
+  const [preparingClaimUnstakeTx, setPreparingClaimUnstakeTx] = useState(false)
 
   const {
-    isLoading: submittingClaimTx,
+    isLoading: submittingClaimUnstakeTx,
     error: claimContractCallError,
     status: claimCallReceiptStatus,
   } = useWaitForTransactionReceipt({
-    hash: claimCallTxHash,
+    hash: claimUnstakeCallTxHash,
   })
 
-  const claim = (delegatorAddress: string) => {
-    setPreparingClaimTx(true)
+  const claimUnstake = (delegatorAddress: string) => {
+    setPreparingClaimUnstakeTx(true)
     if (isDummyWalletConnected) {
       setDummyWalletPopupContent(
         "Now User gonna approve the wallet transaction for withdrawing/claiming ZIL"
       )
       setIsDummyWalletPopupOpen(true)
-      setClaimCallTxHash("0x1234567890234567890234567890234567890" as Address)
-      setPreparingClaimTx(false)
+      setClaimUnstakeCallTxHash(
+        "0x1234567890234567890234567890234567890" as Address
+      )
+      setPreparingClaimUnstakeTx(false)
     } else {
       writeContract(wagmiConfig, {
         address: delegatorAddress as Address,
@@ -195,7 +197,7 @@ const useStakingOperations = () => {
         args: [],
       })
         .then((txHash) => {
-          setClaimCallTxHash(txHash)
+          setClaimUnstakeCallTxHash(txHash)
         })
         .catch((error) => {
           notification.error({
@@ -205,7 +207,7 @@ const useStakingOperations = () => {
             placement: "topRight",
           })
         })
-        .finally(() => setPreparingClaimTx(false))
+        .finally(() => setPreparingClaimUnstakeTx(false))
     }
   }
 
@@ -228,6 +230,39 @@ const useStakingOperations = () => {
   }, [claimCallReceiptStatus])
 
   /**
+   * CLAIM REWARDS
+   */
+
+  const [claimRewardCallTxHash, setClaimRewardCallTxHash] = useState<
+    Address | undefined
+  >(undefined)
+  const [preparingClaimRewardTx, setPreparingClaimRewardTx] = useState(false)
+
+  const {
+    isLoading: submittingClaimRewardTx,
+    error: claimRewardContractCallError,
+    status: claimRewardCallReceiptStatus,
+  } = useWaitForTransactionReceipt({
+    hash: claimRewardCallTxHash,
+  })
+
+  const claimReward = (delegatorAddress: string) => {
+    setPreparingClaimRewardTx(true)
+    if (isDummyWalletConnected) {
+      setDummyWalletPopupContent(
+        "Now User gonna approve the wallet transaction for claiming rewards"
+      )
+      setIsDummyWalletPopupOpen(true)
+      setClaimRewardCallTxHash(
+        "0x1234567890234567890234567890234567890" as Address
+      )
+      setPreparingClaimRewardTx(false)
+    } else {
+      console.error("Claiming rewards not implemented")
+    }
+  }
+
+  /**
    * OTHER
    */
 
@@ -235,7 +270,7 @@ const useStakingOperations = () => {
     function clearStateOnDelegatorChange() {
       setStakingCallTxHash(undefined)
       setUnstakingCallTxHash(undefined)
-      setClaimCallTxHash(undefined)
+      setClaimUnstakeCallTxHash(undefined)
     },
     [stakingPoolId]
   )
@@ -255,10 +290,17 @@ const useStakingOperations = () => {
     unstakingCallTxHash,
     unstakeContractCallError,
 
-    claim,
-    isClaimingInProgress: submittingClaimTx || preparingClaimTx,
-    claimCallTxHash,
+    claimUnstake,
+    isClaimingUnstakeInProgress:
+      submittingClaimUnstakeTx || preparingClaimUnstakeTx,
+    claimUnstakeCallTxHash,
     claimContractCallError,
+
+    claimReward,
+    isClaimingRewardInProgress:
+      submittingClaimRewardTx || preparingClaimRewardTx,
+    claimRewardCallTxHash,
+    claimRewardContractCallError,
   }
 }
 

--- a/src/contexts/stakingPoolsStorage.tsx
+++ b/src/contexts/stakingPoolsStorage.tsx
@@ -9,8 +9,10 @@ import {
   stakingPoolsConfigForChainId,
 } from "@/misc/stakingPoolsConfig"
 import {
+  getWalletNonLiquidStakingPoolRewardData,
   getWalletStakingData,
   getWalletUnstakingData,
+  UserNonLiquidStakingPoolRewardData,
   UserStakingPoolData,
   UserUnstakingPoolData,
 } from "@/misc/walletsConfig"
@@ -30,6 +32,9 @@ const useStakingPoolsStorage = () => {
   >([])
   const [userUnstakesData, setUserUnstakesData] = useState<
     UserUnstakingPoolData[]
+  >([])
+  const [userNonLiquidPoolRewards, setUserNonLiquidPoolRewards] = useState<
+    UserNonLiquidStakingPoolRewardData[]
   >([])
 
   const [stakingPoolForView, setSelectedStakingPool] =
@@ -54,6 +59,11 @@ const useStakingPoolsStorage = () => {
     setIsUnstakingDataLoading(true)
     getWalletUnstakingData(walletAddress, appConfig!.chainId)
       .then(setUserUnstakesData)
+      .catch(console.error)
+      .finally(() => setIsUnstakingDataLoading(false))
+
+    getWalletNonLiquidStakingPoolRewardData(walletAddress, appConfig!.chainId)
+      .then(setUserNonLiquidPoolRewards)
       .catch(console.error)
       .finally(() => setIsUnstakingDataLoading(false))
   }
@@ -235,6 +245,14 @@ const useStakingPoolsStorage = () => {
       )!,
     })) || []
 
+  const combinedUserNonLiquidPoolRewards =
+    userNonLiquidPoolRewards?.map((rewardInfo) => ({
+      rewardInfo,
+      stakingPool: availableStakingPoolsData.find(
+        (pool) => pool.definition.address === rewardInfo.address
+      )!,
+    })) || []
+
   const availableForUnstaking = combinedUserUnstakesData.filter(
     (unstakeData) => unstakeData.unstakeInfo.availableAt <= DateTime.now()
   )
@@ -254,6 +272,7 @@ const useStakingPoolsStorage = () => {
     userUnstakesData,
     availableForUnstaking,
     pendingUnstaking,
+    nonLiquidRewards: combinedUserNonLiquidPoolRewards,
     reloadUserStakingPoolsData,
     isUnstakingDataLoading,
   }

--- a/src/contexts/walletConnector.tsx
+++ b/src/contexts/walletConnector.tsx
@@ -56,7 +56,6 @@ const useWalletConnector = () => {
   /**
    * Rainbow wallet section
    */
-
   const { data: walletClient } = useWalletClient()
 
   /**
@@ -78,6 +77,11 @@ const useWalletConnector = () => {
   const updateWalletBalance = () => {
     if (!walletAddress) {
       setZilAvailable(null)
+      return
+    }
+
+    if (isDummyWalletConnected) {
+      setZilAvailable(dummyWallet!.currentZil)
       return
     }
 

--- a/src/script/fetchPoolStaticData.ts
+++ b/src/script/fetchPoolStaticData.ts
@@ -4,13 +4,17 @@ import { readContract } from "viem/actions"
 import { delegatorAbi } from "@/misc/stakingAbis"
 import { Address, erc20Abi } from "viem"
 import { getViemClient } from "@/misc/chainConfig"
-import { StakingPoolDefinition } from "@/misc/stakingPoolsConfig"
+import {
+  StakingPoolDefinition,
+  StakingPoolType,
+} from "@/misc/stakingPoolsConfig"
 
 interface Args {
   network_id: string
   contract_address: string
   icon_url: string
   name: string
+  type: StakingPoolType
 }
 
 const argv = yargs(hideBin(process.argv))
@@ -33,6 +37,11 @@ const argv = yargs(hideBin(process.argv))
   .option("name", {
     type: "string",
     description: "The name of the pool",
+    demandOption: true,
+  })
+  .option("type", {
+    type: "string",
+    description: "The type of the pool",
     demandOption: true,
   })
   .help()
@@ -81,6 +90,7 @@ const argv = yargs(hideBin(process.argv))
     tokenAddress,
     iconUrl: argv.icon_url,
     name: argv.name,
+    poolType: argv.type,
     tokenDecimals,
     tokenSymbol,
     minimumStake: minimumStake as bigint,


### PR DESCRIPTION
# Description

This PR adds mainly non-visual changes to enable non-liquid staking. The visual changes and the remaining blockchain integration will be added as a follow-up work. 

Additionally, when running in the mocked wallet mode, no viem errors are thrown. 

# Testing

The non-liquid delegator is visible on the `normal staking` tab when running locally with mocked wallet enabled.

