### PR TITLE
APT-1719: Info below stake/unstake same

### DIFF
--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -190,14 +190,14 @@ const StakingCalculator: React.FC = () => {
               </div>
               <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
                 {isPoolLiquid() && (
-                  <div className="flex flex-col xl:flex-row xl:gap-5">
+                  <div className="flex gap-2 xl:gap-5">
                     <div className="gray-base">Rate</div>
                     {stakingPoolForView!.stakingPool.data && (
                       <div className="text-gray9">{`1 ZIL = ~${stakingPoolForView.stakingPool.data.zilToTokenRate.toPrecision(3)} ${stakingPoolForView.stakingPool.definition.tokenSymbol}`}</div>
                     )}
                   </div>
                 )}
-                <div className="text-gray9 text-aqua1 flex flex-row xl:gap-5">
+                <div className="text-aqua1 flex gap-2 xl:gap-5">
                   <Tooltip
                     placement="top"
                     arrow={true}

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -179,7 +179,7 @@ const UnstakingCalculator: React.FC = () => {
               </div>
               <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
                 {isPoolLiquid() && (
-                  <div className="flex flex-col xl:flex-row xl:gap-5">
+                  <div className="flex gap-2 xl:gap-5">
                     <div className="gray-base">Rate</div>
                     <div className="text-gray9">
                       {stakingPoolForView!.stakingPool.data ? (
@@ -206,7 +206,7 @@ const UnstakingCalculator: React.FC = () => {
                   </div>
                 )}
 
-                <div className="text-gray9 flex flex-row xl:gap-5">
+                <div className="text-gray9 flex gap-2 xl:gap-5">
                   <Tooltip
                     placement="top"
                     arrow={true}


### PR DESCRIPTION
#description: font size for info below stake/unstake is same and fixed grid to avoid breaks 

#testing: no break for rate below the stake unstake btns in validator details tabs