### PR TITLE
APT-1741: rewards added to withdraw panel

### DIFF
--- a/src/components/customWalletConnect.tsx
+++ b/src/components/customWalletConnect.tsx
@@ -109,7 +109,7 @@ const CustomWalletConnect: React.FC<CustomWalletConnectProps> = ({
               onClick={openAccountModal}
               className={connectedClassName ?? notConnectedClassName}
             >
-              {account.displayName} | {account.balanceFormatted}{" "}
+              {account.displayName} | {account.balanceDecimals?.toFixed(0)}{" "}
               {account.balanceSymbol}
             </Button>
           )

--- a/src/components/stakingPoolDetailsView.tsx
+++ b/src/components/stakingPoolDetailsView.tsx
@@ -5,6 +5,7 @@ import { WalletConnector } from "@/contexts/walletConnector"
 import { formatPercentage, formatUnitsToHumanReadable } from "@/misc/formatting"
 import { StakingPool, StakingPoolType } from "@/misc/stakingPoolsConfig"
 import {
+  UserNonLiquidStakingPoolRewardData,
   UserStakingPoolData,
   UserUnstakingPoolData,
 } from "@/misc/walletsConfig"
@@ -13,7 +14,6 @@ import { useEffect, useState } from "react"
 import { useWatchAsset } from "wagmi"
 import PlusIcon from "../assets/svgs/plus-icon.svg"
 import Image from "next/image"
-import router from "next/router"
 import CloseIcon from "../assets/svgs/close-icon.svg"
 import FastFadeScroll from "@/components/FastFadeScroll"
 
@@ -24,6 +24,7 @@ interface StakingPoolDetailsViewProps {
   userStakingPoolData?: UserStakingPoolData
   userUnstakingPoolData?: Array<UserUnstakingPoolData>
   viewClaim?: boolean
+  reward?: UserNonLiquidStakingPoolRewardData
 }
 
 const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
@@ -31,6 +32,7 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
   userStakingPoolData,
   userUnstakingPoolData,
   viewClaim,
+  reward,
 }) => {
   const { selectStakingPoolForView } = StakingPoolsStorage.useContainer()
 
@@ -238,6 +240,7 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
           <WithdrawZilPanel
             userUnstakingPoolData={userUnstakingPoolData}
             stakingPoolData={stakingPoolData}
+            reward={reward}
           />
         )}
       </FastFadeScroll>

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -142,24 +142,32 @@ const UnstakingCalculator: React.FC = () => {
             </Button>
           </div>
         </div>
-        <div className="flex flex-col">
+
+        <div className="flex flex-col justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2">
           <div className="flex mt-2 mb-5">
-            <Button
-              type="default"
-              size="large"
-              className="btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua mx-auto lg:w-1/2 w-2/3"
-              disabled={!canUnstake}
-              onClick={() =>
-                unstake(
-                  stakingPoolForView.stakingPool.definition.address,
-                  zilInWei
-                )
-              }
-              loading={isUnstakingInProgress}
-            >
-              Unstake
-            </Button>
+            {isWalletConnected ? (
+              <Button
+                type="default"
+                size="large"
+                className="btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua  mx-auto lg:w-1/2 w-2/3"
+                disabled={!canUnstake}
+                onClick={() =>
+                  unstake(
+                    stakingPoolForView.stakingPool.definition.address,
+                    zilInWei
+                  )
+                }
+                loading={isUnstakingInProgress}
+              >
+                Unstake
+              </Button>
+            ) : (
+              <CustomWalletConnect notConnectedClassName="btn-primary-gradient-aqua sm:px-10 sm:max-w-fit  mx-auto lg:w-1/2 w-2/3">
+                Connect wallet
+              </CustomWalletConnect>
+            )}
           </div>
+
           <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2">
             <div className="flex flex-col gap-3.5 regular-base">
               <div className=" ">
@@ -202,129 +210,33 @@ const UnstakingCalculator: React.FC = () => {
                       <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
                     )}
                     ZIL
-                    <span className="medium17 ml-2 text-aqua1">
-                      {unboudingPeriod}
-                    </span>
                   </div>
                 </div>
               )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  className="btn-secondary-colored text-aqua1 hover:!text-aqua1 border-0 bg-tealDark hover:!bg-tealDark"
-                  onClick={onMaxClick}
-                >
-                  MAX
-                </Button>
-                <Button
-                  className="btn-secondary-colored text-purple3 hover:!text-purple1 border-0 bg-PurpleDarker hover:!bg-PurpleDarker"
-                  onClick={() => setZilToUnstake("0")}
-                >
-                  MIN
-                </Button>
-              </div>
             </div>
-            <div className="flex flex-col">
-              <div className="flex mt-2 mb-5">
-                {isWalletConnected ? (
-                  <Button
-                    type="default"
-                    size="large"
-                    className="btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua mx-auto lg:w-1/2 w-2/3"
-                    disabled={!canUnstake}
-                    onClick={() =>
-                      unstake(
-                        stakingPoolForView.stakingPool.definition.address,
-                        zilInWei
-                      )
-                    }
-                    loading={isUnstakingInProgress}
-                  >
-                    Unstake
-                  </Button>
-                ) : (
-                  <CustomWalletConnect notConnectedClassName="btn-primary-gradient-aqua sm:px-10 sm:max-w-fit  mx-auto lg:w-1/2 w-2/3">
-                    Connect wallet
-                  </CustomWalletConnect>
-                )}
-              </div>
-              <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2">
-                <div className="flex flex-col gap-3.5 regular-base">
-                  <div className=" ">
-                    Commission Fee:{" "}
-                    {stakingPoolForView!.stakingPool.data ? (
-                      <>
-                        {" "}
-                        {formatPercentage(
-                          stakingPoolForView!.stakingPool.data.commission
-                        )}{" "}
-                      </>
-                    ) : (
-                      <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
-                    )}
-                  </div>
-                  <div className="">Max transaction cost: 3 ZIL</div>
-                  <div className="text-aqua1 ">
-                    Unbonding Period: {unboudingPeriod}
-                  </div>
-                </div>
-                <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
-                  {isPoolLiquid() && (
-                    <div className="flex flex-col xl:flex-row xl:gap-5 4k:gap-6">
-                      <div className="gray-base">Rate</div>
-                      <div className="text-gray9">
-                        {stakingPoolForView!.stakingPool.data ? (
-                          <>
-                            1{" "}
-                            {
-                              stakingPoolForView.stakingPool.definition
-                                .tokenSymbol
-                            }{" "}
-                            = ~
-                            {formatUnitsToHumanReadable(
-                              convertTokenToZil(
-                                parseEther("1"),
-                                stakingPoolForView.stakingPool.data
-                                  .zilToTokenRate
-                              ),
-                              18
-                            )}
-                          </>
-                        ) : (
-                          <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
-                        )}
-                        ZIL
-                      </div>
-                    </div>
-                  )}
-                </div>
 
-                <div className="text-gray9 flex flex-row xl:gap-5 4k:gap-6">
-                  <Tooltip
-                    placement="top"
-                    arrow={true}
-                    color="#555555"
-                    className=" mr-1"
-                    title="Annual Percentage Rate"
-                  >
-                    <span className="gray-base">APR </span>
-                  </Tooltip>
+            <div className="text-gray9 flex flex-row xl:gap-5 4k:gap-6">
+              <Tooltip
+                placement="top"
+                arrow={true}
+                color="#555555"
+                className=" mr-1"
+                title="Annual Percentage Rate"
+              >
+                <span className="gray-base">APR </span>
+              </Tooltip>
 
-                  {stakingPoolForView!.stakingPool.data ? (
-                    <>
-                      ~
-                      {formatPercentage(
-                        stakingPoolForView!.stakingPool.data.apr
-                      )}
-                    </>
-                  ) : (
-                    <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
-                  )}
-                </div>
-              </div>
+              {stakingPoolForView!.stakingPool.data ? (
+                <>
+                  ~{formatPercentage(stakingPoolForView!.stakingPool.data.apr)}
+                </>
+              ) : (
+                <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
+              )}
             </div>
           </div>
         </div>
+
         {unstakeContractCallError && (
           <div className="text-red1 text-center">
             {unstakeContractCallError.message}

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -7,23 +7,39 @@ import {
   getTxExplorerUrl,
 } from "@/misc/formatting"
 import { StakingPool } from "@/misc/stakingPoolsConfig"
-import { UserUnstakingPoolData } from "@/misc/walletsConfig"
+import {
+  UserNonLiquidStakingPoolRewardData,
+  UserUnstakingPoolData,
+} from "@/misc/walletsConfig"
 import { Button } from "antd"
 import { DateTime } from "luxon"
 import Link from "next/link"
+import Image from "next/image"
 import { formatUnits } from "viem"
+import rewards from "../assets/svgs/rewards.svg"
 
 interface WithdrawZilPanelProps {
   stakingPoolData: StakingPool
   userUnstakingPoolData?: Array<UserUnstakingPoolData>
+  reward?: UserNonLiquidStakingPoolRewardData
 }
 
 const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
   userUnstakingPoolData,
   stakingPoolData,
+  reward,
 }) => {
-  const { claimUnstake, isClaimingUnstakeInProgress, claimUnstakeCallTxHash } =
-    StakingOperations.useContainer()
+  const {
+    claimUnstake,
+    isClaimingUnstakeInProgress,
+    claimUnstakeCallTxHash,
+    claimReward,
+    isClaimingRewardInProgress,
+    claimRewardCallTxHash,
+    stakeReward,
+    isStakingRewardInProgress,
+    stakeRewardCallTxHash,
+  } = StakingOperations.useContainer()
 
   const { appConfig } = AppConfigStorage.useContainer()
 
@@ -41,18 +57,63 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
         claimA.availableAt.diff(claimB.availableAt).milliseconds
     )
 
+  const hashToShow =
+    claimRewardCallTxHash || stakeRewardCallTxHash || claimUnstakeCallTxHash
+
   return (
     <div className="h-full">
-      {claimUnstakeCallTxHash !== undefined && (
+      {hashToShow !== undefined && (
         <div className="text-center gradient-bg-1 py-2 text-gray-500">
           <Link
             rel="noopener noreferrer"
             target="_blank"
-            href={getTxExplorerUrl(claimUnstakeCallTxHash, appConfig.chainId)}
+            href={getTxExplorerUrl(hashToShow, appConfig.chainId)}
             passHref={true}
           >
-            Last staking transaction: {formatAddress(claimUnstakeCallTxHash)}
+            Last staking transaction: {formatAddress(hashToShow)}
           </Link>
+        </div>
+      )}
+
+      {reward && (
+        <div
+          className=" min-h-[100px] lg:min-h-[124px] xl:min-h-[140px] 
+            flex flex-col justify-evenly gap-2 4k:gap-3 my-2.5 lg:my-4 4k:my-6 p-3 lg:p-5 xl:p-7 4k:p-10 bg-grey-gradient rounded-xl w-full"
+        >
+          <div className="items-center h4 w-full flex justify-between text-white1">
+            {stakingPoolData.data ? (
+              <div>
+                <div className="body2">
+                  <span className="mr-1 text-aqua2">Available</span>
+                  <span className="text-aqua1">rewards</span>
+                </div>
+                <div>
+                  {parseFloat(formatUnits(reward.zilRewardAmount, 18)).toFixed(
+                    3
+                  )}{" "}
+                  ZIL
+                </div>
+              </div>
+            ) : (
+              <div className="w-[4em] h-[1em] animated-gradient" />
+            )}
+            <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[218px] w-full">
+              <Button
+                className="btn-secondary-grey lg:py-5 py-4 mb-2.5"
+                onClick={() => stakeReward(reward.address)}
+                loading={isStakingRewardInProgress}
+              >
+                Stake Reward
+              </Button>
+              <Button
+                className="btn-secondary-grey lg:py-5 py-4"
+                onClick={() => claimReward(reward.address)}
+                loading={isClaimingRewardInProgress}
+              >
+                Claim Reward
+              </Button>
+            </div>
+          </div>
         </div>
       )}
 
@@ -65,11 +126,14 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
           >
             <div className="items-center h4 w-full flex justify-between text-white1">
               {stakingPoolData.data ? (
-                <div className="flex">
+                <div>
+                  <div className="body2">
+                    <span className="mr-1 text-aqua2">Available</span>
+                    <span className="text-aqua1">requests</span>
+                  </div>
                   <div>
                     {parseFloat(formatUnits(item.zilAmount, 18)).toFixed(3)} ZIL
                   </div>
-                  <div className="body1-s lg:ml-2.5 mt-2">avZIL</div>
                 </div>
               ) : (
                 <div className="w-[4em] h-[1em] animated-gradient" />
@@ -92,7 +156,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
          my-2.5 lg:my-4 4k:my-6 py-2 lg:py-6 xl:py-8 4k:py-10 
          px-3 lg:px-7.5 xl:px-10 4k:px-14 bg-grey-gradient rounded-xl w-full"
         >
-          <div className="body2 text-gray1">Next available reward</div>
+          <div className="body2 text-gray1">Next available unstake request</div>
           <div className="h4 mt-2 w-full flex justify-between text-white1">
             <div>{getHumanFormDuration(pendingUnstake[0].availableAt)}</div>
             {stakingPoolData.data ? (
@@ -107,10 +171,12 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
             )}
           </div>
         </div>
-      ) : (
+      ) : !reward ? (
         <div className="flex justify-center items-center h-full body2 text-gray1 ">
           No available Claims
         </div>
+      ) : (
+        <></>
       )}
 
       {!!pendingUnstake?.length && (

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -89,7 +89,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
                 </div>
                 <div>
                   {parseFloat(formatUnits(reward.zilRewardAmount, 18)).toFixed(
-                    3
+                    5
                   )}{" "}
                   ZIL
                 </div>

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -102,14 +102,6 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
               : getHumanFormDuration(unstakeInfo.availableAt) + " left"}
           </Button>
         </div>
-        {/* <div className="max-lg:w-1/2 lg:mt-2.5">
-            <Button
-              className="btn-secondary-grey lg:py-5 py-4"
-              onClick={() => selectStakingPoolForView(stakingPool.definition.id)}
-            >
-              View
-            </Button>
-          </div> */}
       </div>
     </div>
   )

--- a/src/contexts/stakingPoolsStorage.tsx
+++ b/src/contexts/stakingPoolsStorage.tsx
@@ -201,6 +201,10 @@ const useStakingPoolsStorage = () => {
             (userPoolData) =>
               userPoolData.address === stakingPoolForView.definition.address
           ),
+          reward: userNonLiquidPoolRewards.find(
+            (userPoolData) =>
+              userPoolData.address === stakingPoolForView.definition.address
+          ),
         },
       }
     : null

--- a/src/misc/walletsConfig.ts
+++ b/src/misc/walletsConfig.ts
@@ -145,6 +145,16 @@ export const dummyWallets: Array<DummyWallet> = [
         zilAmount: parseUnits("100", 18),
         availableAt: DateTime.now().plus({ days: 5 }),
       },
+      {
+        address: "0xe863906941de820bde06701a0d804dd0b8575d67",
+        zilAmount: parseUnits("220.2", 18),
+        availableAt: DateTime.now().minus({ days: 5 }),
+      },
+      {
+        address: "0xe863906941de820bde06701a0d804dd0b8575d67",
+        zilAmount: parseUnits("440.2", 18),
+        availableAt: DateTime.now().plus({ days: 5 }),
+      },
     ],
     nonLiquidRewards: [
       {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -80,6 +80,7 @@ const HomePage = () => {
             userStakingPoolData={stakingPoolForView.userData.staked}
             userUnstakingPoolData={stakingPoolForView.userData.unstaked}
             viewClaim={viewClaim}
+            reward={stakingPoolForView.userData.reward}
           />
         </div>
       ) : (


### PR DESCRIPTION
# Description

- now rewards are visible under the `Claims` tab when available
- unstaking calculator UI fixed
- use balance is now not showing decimal places
- reward value in the claim panel is now showing more decimal places

# Testing

I tested with mocked wallet that the app looks fine when I have and don't have rewards.  