### PR TITLE
APT-1763: Rewards visible on mobile

### DIFF
--- a/src/components/customWalletConnect.tsx
+++ b/src/components/customWalletConnect.tsx
@@ -109,7 +109,7 @@ const CustomWalletConnect: React.FC<CustomWalletConnectProps> = ({
               onClick={openAccountModal}
               className={connectedClassName ?? notConnectedClassName}
             >
-              {account.displayName} | {account.balanceDecimals?.toFixed(0)}{" "}
+              {account.displayName} | {account.balanceFormatted?.split(".")[0]}{" "}
               {account.balanceSymbol}
             </Button>
           )

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -14,9 +14,7 @@ import {
 import { Button } from "antd"
 import { DateTime } from "luxon"
 import Link from "next/link"
-import Image from "next/image"
 import { formatUnits } from "viem"
-import rewards from "../assets/svgs/rewards.svg"
 
 interface WithdrawZilPanelProps {
   stakingPoolData: StakingPool

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -98,6 +98,7 @@ const HomePage = () => {
             stakingPoolData={stakingPoolForView.stakingPool}
             userStakingPoolData={stakingPoolForView.userData.staked}
             userUnstakingPoolData={stakingPoolForView.userData.unstaked}
+            reward={stakingPoolForView.userData.reward}
           />
         )
 


### PR DESCRIPTION
# Description

`rewards` data is now properly routed for mobile UI

# Testing

Rewards visible both on desktop and mobile when testing locally.