### PR TITLE
Apt-1751-APT-1758-APT-1761-APT-1753-APT-1760-APT-1756 + lama comments + re fix some broken items

### DIFF
--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -8,6 +8,7 @@ import {
   convertZilValueInToken,
   getTxExplorerUrl,
   formatAddress,
+  getHumanFormDuration,
 } from "@/misc/formatting"
 import { formatUnits, parseEther } from "viem"
 import { StakingOperations } from "@/contexts/stakingOperations"
@@ -15,6 +16,7 @@ import { AppConfigStorage } from "@/contexts/appConfigStorage"
 import Link from "next/link"
 import { StakingPoolType } from "@/misc/stakingPoolsConfig"
 import CustomWalletConnect from "./customWalletConnect"
+import { DateTime } from "luxon"
 
 const StakingCalculator: React.FC = () => {
   const { appConfig } = AppConfigStorage.useContainer()
@@ -91,6 +93,13 @@ const StakingCalculator: React.FC = () => {
   const isPoolLiquid = () =>
     stakingPoolForView?.stakingPool.definition.poolType ===
     StakingPoolType.LIQUID
+
+      const unboudingPeriod = getHumanFormDuration(
+        DateTime.now().plus({
+          minutes:
+            stakingPoolForView?.stakingPool.definition.withdrawPeriodInMinutes || 0,
+        })
+      )
 
   return (
     stakingPoolForView && (
@@ -211,6 +220,9 @@ const StakingCalculator: React.FC = () => {
                   )}
                 </div>
                 <div className="">Max transaction cost: 3 ZIL</div>
+                <div className="text-aqua1 ">
+                Unbonding Period: {unboudingPeriod}
+              </div>
               </div>
               <div className="flex flex-col max-xl:justify-between xl:gap-3.5 4k:gap-5 xl:items-end">
                 {isPoolLiquid() && (

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -168,7 +168,7 @@ const StakingCalculator: React.FC = () => {
             </div>
           </div>
           <div className="flex flex-col">
-            <div className="flex mt-2 mb-2 ">
+            <div className="flex mt-2 mb-3">
               {isWalletConnected ? (
                 <Button
                   type="default"

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -205,7 +205,7 @@ const StakingCalculator: React.FC = () => {
           </div>
         )}
 
-            <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2 ">
+            <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2 lg:pb-10">
               <div className="flex flex-col gap-3.5 4k:gap-4 regular-base">
                 <div className=" ">
                   Commission Fee:{" "}

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -94,12 +94,12 @@ const StakingCalculator: React.FC = () => {
     stakingPoolForView?.stakingPool.definition.poolType ===
     StakingPoolType.LIQUID
 
-      const unboudingPeriod = getHumanFormDuration(
-        DateTime.now().plus({
-          minutes:
-            stakingPoolForView?.stakingPool.definition.withdrawPeriodInMinutes || 0,
-        })
-      )
+  const unboudingPeriod = getHumanFormDuration(
+    DateTime.now().plus({
+      minutes:
+        stakingPoolForView?.stakingPool.definition.withdrawPeriodInMinutes || 0,
+    })
+  )
 
   return (
     stakingPoolForView && (
@@ -191,19 +191,23 @@ const StakingCalculator: React.FC = () => {
                 </CustomWalletConnect>
               )}
             </div>
-       
-        {stakingCallTxHash !== undefined && (
-          <div className="text-center mb-3 regular-base ">
-            <Link
-              rel="noopener noreferrer"
-              target="_blank"
-              href={getTxExplorerUrl(stakingCallTxHash, appConfig.chainId)}
-              passHref={true}
-            >
-              Last staking transaction: <span className="text-white underline"> {formatAddress(stakingCallTxHash)}</span> 
-            </Link>
-          </div>
-        )}
+
+            {stakingCallTxHash !== undefined && (
+              <div className="text-center mb-3 regular-base ">
+                <Link
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  href={getTxExplorerUrl(stakingCallTxHash, appConfig.chainId)}
+                  passHref={true}
+                >
+                  Last staking transaction:{" "}
+                  <span className="text-white underline">
+                    {" "}
+                    {formatAddress(stakingCallTxHash)}
+                  </span>
+                </Link>
+              </div>
+            )}
 
             <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2 lg:pb-10">
               <div className="flex flex-col gap-3.5 4k:gap-4 regular-base">
@@ -221,8 +225,8 @@ const StakingCalculator: React.FC = () => {
                 </div>
                 <div className="">Max transaction cost: 3 ZIL</div>
                 <div className="text-aqua1 ">
-                Unbonding Period: {unboudingPeriod}
-              </div>
+                  Unbonding Period: {unboudingPeriod}
+                </div>
               </div>
               <div className="flex flex-col max-xl:justify-between xl:gap-3.5 4k:gap-5 xl:items-end">
                 {isPoolLiquid() && (
@@ -258,7 +262,6 @@ const StakingCalculator: React.FC = () => {
             </div>
           </div>
         </div>
-
 
         {stakeContractCallError && (
           <div className="text-red1 text-center">

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -159,7 +159,7 @@ const StakingCalculator: React.FC = () => {
             </div>
           </div>
           <div className="flex flex-col">
-            <div className="flex mt-2 mb-5 ">
+            <div className="flex mt-2 mb-2 ">
               {isWalletConnected ? (
                 <Button
                   type="default"
@@ -182,6 +182,20 @@ const StakingCalculator: React.FC = () => {
                 </CustomWalletConnect>
               )}
             </div>
+       
+        {stakingCallTxHash !== undefined && (
+          <div className="text-center mb-3 regular-base ">
+            <Link
+              rel="noopener noreferrer"
+              target="_blank"
+              href={getTxExplorerUrl(stakingCallTxHash, appConfig.chainId)}
+              passHref={true}
+            >
+              Last staking transaction: <span className="text-white underline"> {formatAddress(stakingCallTxHash)}</span> 
+            </Link>
+          </div>
+        )}
+
             <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2 ">
               <div className="flex flex-col gap-3.5 4k:gap-4 regular-base">
                 <div className=" ">
@@ -233,18 +247,6 @@ const StakingCalculator: React.FC = () => {
           </div>
         </div>
 
-        {stakingCallTxHash !== undefined && (
-          <div className="text-center gradient-bg-1 py-2">
-            <Link
-              rel="noopener noreferrer"
-              target="_blank"
-              href={getTxExplorerUrl(stakingCallTxHash, appConfig.chainId)}
-              passHref={true}
-            >
-              Last staking transaction: {formatAddress(stakingCallTxHash)}
-            </Link>
-          </div>
-        )}
 
         {stakeContractCallError && (
           <div className="text-red1 text-center">

--- a/src/components/stakingPoolDetailsView.tsx
+++ b/src/components/stakingPoolDetailsView.tsx
@@ -229,7 +229,7 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
         ))}
       </div>
 
-      <FastFadeScroll className="flex-1 pb-4 mb-16 md:mb-0 overflow-y-scroll">
+      <FastFadeScroll className="flex-1 pb-4 mb-16 lg:mb-0 overflow-y-scroll">
         {selectedPane === "Stake" ? (
           <StakingCalculator />
         ) : selectedPane === "Unstake" ? (

--- a/src/components/stakingPoolDetailsView.tsx
+++ b/src/components/stakingPoolDetailsView.tsx
@@ -103,37 +103,39 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
       }
     )
 
+  const greyInfoEntries = [
+    stakingPoolData.data &&
+      greyInfoEntry(
+        "Voting power",
+        formatPercentage(stakingPoolData.data.votingPower)
+      ),
 
-    const greyInfoEntries = [
-      stakingPoolData.data &&
-        greyInfoEntry("Voting power", formatPercentage(stakingPoolData.data.votingPower)),
-    
-      stakingPoolData.data &&
-        greyInfoEntry(
-          "Total supply",
-          `${humanReadableStakingToken(stakingPoolData.data.tvl)} ${stakingPoolData.definition.tokenSymbol}`
-        ),
-    
-      stakingPoolData.data &&
-        greyInfoEntry("Commission", formatPercentage(stakingPoolData.data.commission)),
-    
-      isPoolLiquid() &&
-        stakingPoolData.data &&
-        greyInfoEntry(
-          "",
-          <>
-            1 ZIL ~ <br />
-            {stakingPoolData.data.zilToTokenRate.toPrecision(3)}{" "}
-            {stakingPoolData.definition.tokenSymbol}
-          </>
-        ),
-    ];
-    
-     const availableEntries = greyInfoEntries.filter(Boolean);
-    const columnCount = availableEntries.length; 
-    
+    stakingPoolData.data &&
+      greyInfoEntry(
+        "Total supply",
+        `${humanReadableStakingToken(stakingPoolData.data.tvl)} ${stakingPoolData.definition.tokenSymbol}`
+      ),
 
-    
+    stakingPoolData.data &&
+      greyInfoEntry(
+        "Commission",
+        formatPercentage(stakingPoolData.data.commission)
+      ),
+
+    isPoolLiquid() &&
+      stakingPoolData.data &&
+      greyInfoEntry(
+        "",
+        <>
+          1 ZIL ~ <br />
+          {stakingPoolData.data.zilToTokenRate.toPrecision(3)}{" "}
+          {stakingPoolData.definition.tokenSymbol}
+        </>
+      ),
+  ]
+
+  const availableEntries = greyInfoEntries.filter(Boolean)
+  const columnCount = availableEntries.length
 
   return (
     <div className="relative pb-2 4k:pb-4 pr-2 lg:pr-4 4k:pr-6 flex flex-col h-full">
@@ -215,19 +217,19 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
           </div>
         )}
 
-<div
-    className={`grid gap-4 4k:gap-6 ${
-      columnCount === 1
-        ? "grid-cols-1"
-        : columnCount === 2
-        ? "grid-cols-2"
-        : columnCount === 3
-        ? "grid-cols-3"
-        : "grid-cols-4"
-    }`}
-  >
-    {availableEntries}
-  </div>
+        <div
+          className={`grid gap-4 4k:gap-6 ${
+            columnCount === 1
+              ? "grid-cols-1"
+              : columnCount === 2
+                ? "grid-cols-2"
+                : columnCount === 3
+                  ? "grid-cols-3"
+                  : "grid-cols-4"
+          }`}
+        >
+          {availableEntries}
+        </div>
       </div>
       <div className="grid grid-cols-3 my-2 4k:my-4">
         {["Stake", "Unstake", "Claim"].map((pane) => (

--- a/src/components/stakingPoolDetailsView.tsx
+++ b/src/components/stakingPoolDetailsView.tsx
@@ -103,6 +103,38 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
       }
     )
 
+
+    const greyInfoEntries = [
+      stakingPoolData.data &&
+        greyInfoEntry("Voting power", formatPercentage(stakingPoolData.data.votingPower)),
+    
+      stakingPoolData.data &&
+        greyInfoEntry(
+          "Total supply",
+          `${humanReadableStakingToken(stakingPoolData.data.tvl)} ${stakingPoolData.definition.tokenSymbol}`
+        ),
+    
+      stakingPoolData.data &&
+        greyInfoEntry("Commission", formatPercentage(stakingPoolData.data.commission)),
+    
+      isPoolLiquid() &&
+        stakingPoolData.data &&
+        greyInfoEntry(
+          "",
+          <>
+            1 ZIL ~ <br />
+            {stakingPoolData.data.zilToTokenRate.toPrecision(3)}{" "}
+            {stakingPoolData.definition.tokenSymbol}
+          </>
+        ),
+    ];
+    
+     const availableEntries = greyInfoEntries.filter(Boolean);
+    const columnCount = availableEntries.length; 
+    
+
+    
+
   return (
     <div className="relative pb-2 4k:pb-4 pr-2 lg:pr-4 4k:pr-6 flex flex-col h-full">
       <div className="items-center flex justify-between py-1 lg:py-7.5">
@@ -182,36 +214,20 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
             )}
           </div>
         )}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 4k:gap-6">
-          {greyInfoEntry(
-            "Voting power",
-            stakingPoolData.data &&
-              formatPercentage(stakingPoolData.data.votingPower)
-          )}
-          {greyInfoEntry(
-            "Total supply",
-            stakingPoolData.data &&
-              `${humanReadableStakingToken(
-                stakingPoolData.data.tvl
-              )} ${stakingPoolData.definition.tokenSymbol}`
-          )}
-          {greyInfoEntry(
-            "Commission",
-            stakingPoolData.data &&
-              formatPercentage(stakingPoolData.data.commission)
-          )}
-          {isPoolLiquid() &&
-            greyInfoEntry(
-              "",
-              stakingPoolData.data && (
-                <>
-                  1 ZIL ~ <br />
-                  {stakingPoolData.data.zilToTokenRate.toPrecision(3)}{" "}
-                  {stakingPoolData.definition.tokenSymbol}
-                </>
-              )
-            )}
-        </div>
+
+<div
+    className={`grid gap-4 4k:gap-6 ${
+      columnCount === 1
+        ? "grid-cols-1"
+        : columnCount === 2
+        ? "grid-cols-2"
+        : columnCount === 3
+        ? "grid-cols-3"
+        : "grid-cols-4"
+    }`}
+  >
+    {availableEntries}
+  </div>
       </div>
       <div className="grid grid-cols-3 my-2 4k:my-4">
         {["Stake", "Unstake", "Claim"].map((pane) => (

--- a/src/components/stakingPoolsList.tsx
+++ b/src/components/stakingPoolsList.tsx
@@ -132,7 +132,8 @@ const StakingPoolsList: React.FC<StakingPoolsListProps> = ({
                   stakingPool.definition.id
                 }
                 onClick={() =>
-                  selectStakingPoolForView(stakingPool.definition.id)
+{                selectStakingPoolForView(stakingPool.definition.id)
+                setViewClaim(false)}
                 }
               />
             ))}

--- a/src/components/stakingPoolsList.tsx
+++ b/src/components/stakingPoolsList.tsx
@@ -131,10 +131,10 @@ const StakingPoolsList: React.FC<StakingPoolsListProps> = ({
                   stakingPoolForView?.stakingPool.definition.id ===
                   stakingPool.definition.id
                 }
-                onClick={() =>
-{                selectStakingPoolForView(stakingPool.definition.id)
-                setViewClaim(false)}
-                }
+                onClick={() => {
+                  selectStakingPoolForView(stakingPool.definition.id)
+                  setViewClaim(false)
+                }}
               />
             ))}
           </div>

--- a/src/components/stakingPoolsList.tsx
+++ b/src/components/stakingPoolsList.tsx
@@ -120,7 +120,7 @@ const StakingPoolsList: React.FC<StakingPoolsListProps> = ({
           />
         </div>
 
-        <FastFadeScroll className="flex-1 pb-4 mb-16 md:mb-0 overflow-y-scroll">
+        <FastFadeScroll className="flex-1 pb-8 lg:pb-4 mb-16 md:mb-0 overflow-y-scroll">
           <div className="grid grid-cols-1 gap-2.5 lg:gap-4 4k:gap-5">
             {sortedLiquidStakingPoolsData.map(({ stakingPool, userData }) => (
               <StakingPoolCard

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -168,7 +168,7 @@ const UnstakingCalculator: React.FC = () => {
             )}
           </div>
 
-          <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2">
+          <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2 lg:pb-10">
             <div className="flex flex-col gap-3.5 regular-base">
               <div className=" ">
                 Commission Fee:{" "}
@@ -188,6 +188,7 @@ const UnstakingCalculator: React.FC = () => {
                 Unbonding Period: {unboudingPeriod}
               </div>
             </div>
+            <div className="flex flex-col justify-between">
             <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
               {isPoolLiquid() && (
                 <div className="flex flex-col xl:flex-row xl:gap-5 4k:gap-6">
@@ -233,6 +234,7 @@ const UnstakingCalculator: React.FC = () => {
               ) : (
                 <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
               )}
+            </div>
             </div>
           </div>
         </div>

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -189,52 +189,56 @@ const UnstakingCalculator: React.FC = () => {
               </div>
             </div>
             <div className="flex flex-col justify-between">
-            <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
-              {isPoolLiquid() && (
-                <div className="flex flex-col xl:flex-row xl:gap-5 4k:gap-6">
-                  <div className="gray-base">Rate</div>
-                  <div className="text-gray9">
-                    {stakingPoolForView!.stakingPool.data ? (
-                      <>
-                        1{" "}
-                        {stakingPoolForView.stakingPool.definition.tokenSymbol}{" "}
-                        = ~
-                        {formatUnitsToHumanReadable(
-                          convertTokenToZil(
-                            parseEther("1"),
-                            stakingPoolForView.stakingPool.data.zilToTokenRate
-                          ),
-                          18
-                        )}
-                      </>
-                    ) : (
-                      <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
-                    )}
-                    ZIL
+              <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
+                {isPoolLiquid() && (
+                  <div className="flex flex-col xl:flex-row xl:gap-5 4k:gap-6">
+                    <div className="gray-base">Rate</div>
+                    <div className="text-gray9">
+                      {stakingPoolForView!.stakingPool.data ? (
+                        <>
+                          1{" "}
+                          {
+                            stakingPoolForView.stakingPool.definition
+                              .tokenSymbol
+                          }{" "}
+                          = ~
+                          {formatUnitsToHumanReadable(
+                            convertTokenToZil(
+                              parseEther("1"),
+                              stakingPoolForView.stakingPool.data.zilToTokenRate
+                            ),
+                            18
+                          )}
+                        </>
+                      ) : (
+                        <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
+                      )}
+                      ZIL
+                    </div>
                   </div>
-                </div>
-              )}
-            </div>
+                )}
+              </div>
 
-            <div className="text-gray9 flex flex-row xl:gap-5 4k:gap-6">
-              <Tooltip
-                placement="top"
-                arrow={true}
-                color="#555555"
-                className=" mr-1"
-                title="Annual Percentage Rate"
-              >
-                <span className="gray-base">APR </span>
-              </Tooltip>
+              <div className="text-gray9 flex flex-row xl:gap-5 4k:gap-6">
+                <Tooltip
+                  placement="top"
+                  arrow={true}
+                  color="#555555"
+                  className=" mr-1"
+                  title="Annual Percentage Rate"
+                >
+                  <span className="gray-base">APR </span>
+                </Tooltip>
 
-              {stakingPoolForView!.stakingPool.data ? (
-                <>
-                  ~{formatPercentage(stakingPoolForView!.stakingPool.data.apr)}
-                </>
-              ) : (
-                <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
-              )}
-            </div>
+                {stakingPoolForView!.stakingPool.data ? (
+                  <>
+                    ~
+                    {formatPercentage(stakingPoolForView!.stakingPool.data.apr)}
+                  </>
+                ) : (
+                  <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -142,24 +142,32 @@ const UnstakingCalculator: React.FC = () => {
             </Button>
           </div>
         </div>
-        <div className="flex flex-col">
+
+        <div className="flex flex-col justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2">
           <div className="flex mt-2 mb-5">
-            <Button
-              type="default"
-              size="large"
-              className="btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua mx-auto lg:w-1/2 w-2/3"
-              disabled={!canUnstake}
-              onClick={() =>
-                unstake(
-                  stakingPoolForView.stakingPool.definition.address,
-                  zilInWei
-                )
-              }
-              loading={isUnstakingInProgress}
-            >
-              Unstake
-            </Button>
+            {isWalletConnected ? (
+              <Button
+                type="default"
+                size="large"
+                className="btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua  mx-auto lg:w-1/2 w-2/3"
+                disabled={!canUnstake}
+                onClick={() =>
+                  unstake(
+                    stakingPoolForView.stakingPool.definition.address,
+                    zilInWei
+                  )
+                }
+                loading={isUnstakingInProgress}
+              >
+                Unstake
+              </Button>
+            ) : (
+              <CustomWalletConnect notConnectedClassName="btn-primary-gradient-aqua sm:px-10 sm:max-w-fit  mx-auto lg:w-1/2 w-2/3">
+                Connect wallet
+              </CustomWalletConnect>
+            )}
           </div>
+
           <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2">
             <div className="flex flex-col gap-3.5 regular-base">
               <div className=" ">
@@ -202,129 +210,33 @@ const UnstakingCalculator: React.FC = () => {
                       <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
                     )}
                     ZIL
-                    <span className="medium17 ml-2 text-aqua1">
-                      {unboudingPeriod}
-                    </span>
                   </div>
                 </div>
               )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  className="btn-secondary-colored text-aqua1 hover:!text-aqua1 border-0 bg-tealDark hover:!bg-tealDark"
-                  onClick={onMaxClick}
-                >
-                  MAX
-                </Button>
-                <Button
-                  className="btn-secondary-colored text-purple3 hover:!text-purple1 border-0 bg-PurpleDarker hover:!bg-PurpleDarker"
-                  onClick={() => setZilToUnstake("0")}
-                >
-                  MIN
-                </Button>
-              </div>
             </div>
-            <div className="flex flex-col">
-              <div className="flex mt-2 mb-5">
-                {isWalletConnected ? (
-                  <Button
-                    type="default"
-                    size="large"
-                    className="btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua mx-auto lg:w-1/2 w-2/3"
-                    disabled={!canUnstake}
-                    onClick={() =>
-                      unstake(
-                        stakingPoolForView.stakingPool.definition.address,
-                        zilInWei
-                      )
-                    }
-                    loading={isUnstakingInProgress}
-                  >
-                    Unstake
-                  </Button>
-                ) : (
-                  <CustomWalletConnect notConnectedClassName="btn-primary-gradient-aqua sm:px-10 sm:max-w-fit  mx-auto lg:w-1/2 w-2/3">
-                    Connect wallet
-                  </CustomWalletConnect>
-                )}
-              </div>
-              <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2">
-                <div className="flex flex-col gap-3.5 regular-base">
-                  <div className=" ">
-                    Commission Fee:{" "}
-                    {stakingPoolForView!.stakingPool.data ? (
-                      <>
-                        {" "}
-                        {formatPercentage(
-                          stakingPoolForView!.stakingPool.data.commission
-                        )}{" "}
-                      </>
-                    ) : (
-                      <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
-                    )}
-                  </div>
-                  <div className="">Max transaction cost: 3 ZIL</div>
-                  <div className="text-aqua1 ">
-                    Unbonding Period: {unboudingPeriod}
-                  </div>
-                </div>
-                <div className="flex flex-col max-xl:justify-between xl:gap-3.5 xl:items-end">
-                  {isPoolLiquid() && (
-                    <div className="flex flex-col xl:flex-row xl:gap-5 4k:gap-6">
-                      <div className="gray-base">Rate</div>
-                      <div className="text-gray9">
-                        {stakingPoolForView!.stakingPool.data ? (
-                          <>
-                            1{" "}
-                            {
-                              stakingPoolForView.stakingPool.definition
-                                .tokenSymbol
-                            }{" "}
-                            = ~
-                            {formatUnitsToHumanReadable(
-                              convertTokenToZil(
-                                parseEther("1"),
-                                stakingPoolForView.stakingPool.data
-                                  .zilToTokenRate
-                              ),
-                              18
-                            )}
-                          </>
-                        ) : (
-                          <div className="animated-gradient mr-1 h-[1.5em] w-[3em]"></div>
-                        )}
-                        ZIL
-                      </div>
-                    </div>
-                  )}
-                </div>
 
-                <div className="text-gray9 flex flex-row xl:gap-5 4k:gap-6">
-                  <Tooltip
-                    placement="top"
-                    arrow={true}
-                    color="#555555"
-                    className=" mr-1"
-                    title="Annual Percentage Rate"
-                  >
-                    <span className="gray-base">APR </span>
-                  </Tooltip>
+            <div className="text-gray9 flex flex-row xl:gap-5 4k:gap-6">
+              <Tooltip
+                placement="top"
+                arrow={true}
+                color="#555555"
+                className=" mr-1"
+                title="Annual Percentage Rate"
+              >
+                <span className="gray-base">APR </span>
+              </Tooltip>
 
-                  {stakingPoolForView!.stakingPool.data ? (
-                    <>
-                      ~
-                      {formatPercentage(
-                        stakingPoolForView!.stakingPool.data.apr
-                      )}
-                    </>
-                  ) : (
-                    <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
-                  )}
-                </div>
-              </div>
+              {stakingPoolForView!.stakingPool.data ? (
+                <>
+                  ~{formatPercentage(stakingPoolForView!.stakingPool.data.apr)}
+                </>
+              ) : (
+                <div className="animated-gradient ml-1 h-[1em] w-[2em]"></div>
+              )}
             </div>
           </div>
         </div>
+
         {unstakeContractCallError && (
           <div className="text-red1 text-center">
             {unstakeContractCallError.message}

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -143,8 +143,8 @@ const UnstakingCalculator: React.FC = () => {
           </div>
         </div>
 
-        <div className="flex flex-col justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2">
-          <div className="flex mt-2 mb-5">
+        <div className="flex flex-col justify-between">
+          <div className="flex mt-2 mb-3">
             {isWalletConnected ? (
               <Button
                 type="default"

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -143,7 +143,7 @@ const UnstakingCalculator: React.FC = () => {
           </div>
         </div>
 
-         <div className="flex flex-col justify-between">
+        <div className="flex flex-col justify-between">
           <div className="flex mt-2 mb-3">
             {isWalletConnected ? (
               <Button
@@ -167,7 +167,7 @@ const UnstakingCalculator: React.FC = () => {
               </CustomWalletConnect>
             )}
           </div>
- 
+
           <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2 lg:pb-10">
             <div className="flex flex-col gap-3.5 regular-base">
               <div className=" ">

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -44,7 +44,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
   return (
     <div className="h-full">
       {claimUnstakeCallTxHash !== undefined && (
-        <div className="text-center gradient-bg-1 py-2 text-gray-500">
+        <div className="text-center gradient-bg-1 py-2 regular-base">
           <Link
             rel="noopener noreferrer"
             target="_blank"

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -65,7 +65,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
           >
             <div className="items-center h4 w-full flex justify-between text-white1">
               {stakingPoolData.data ? (
-                <div className="flex">
+                <div className="flex items-center gap-1">
                   <div>
                     {parseFloat(formatUnits(item.zilAmount, 18)).toFixed(3)} ZIL
                   </div>
@@ -74,7 +74,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
               ) : (
                 <div className="w-[4em] h-[1em] animated-gradient" />
               )}
-              <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[218px] w-full">
+              <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 max-w-[218px] w-full">
                 <Button
                   className="btn-secondary-grey lg:py-5 py-4"
                   onClick={() => claimUnstake(item.address)}

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -124,7 +124,6 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
           >
             <div className="items-center h4 w-full flex justify-between text-white1">
               {stakingPoolData.data ? (
-
                 <div>
                   <div className="body2">
                     <span className="mr-1 text-aqua2">Available</span>

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -9,7 +9,7 @@ import {
   getHumanFormDuration,
 } from "@/misc/formatting"
 import FeedbackIcon from "../assets/svgs/feedback-icon.svg"
-import { StakingPool } from "@/misc/stakingPoolsConfig"
+import { StakingPool, StakingPoolType } from "@/misc/stakingPoolsConfig"
 import {
   UserNonLiquidStakingPoolRewardData,
   UserUnstakingPoolData,
@@ -55,6 +55,7 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
           />
           <div className="semi24">{stakingPool.definition.name}</div>
           <div className="text-gray4 lg:hidden text-20">|</div>
+          {stakingPool.definition.poolType != StakingPoolType.LIQUID &&
           <div className="bg-gray4 text-white3 py-1 4k:py-1.5 px-2 4k:px-2.5 items-center gap-2 4k:gap-2.5 medium12 lg:flex hidden">
             <Image
               className="rounded"
@@ -64,7 +65,7 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
               height={15}
             />
             Requests
-          </div>
+          </div>}
         </div>
         <div className="flex lg:mt-3 items-center">
           <div className="bold33">
@@ -151,6 +152,7 @@ const RewardCard: React.FC<RewardCardProps> = ({
           />
           <div className="semi24">{stakingPool.definition.name}</div>
           <div className="text-gray4 lg:hidden text-20">|</div>
+          {stakingPool.definition.poolType != StakingPoolType.LIQUID &&
           <div className="bg-gray4 text-white3 py-1 4k:py-1.5 px-2 4k:px-2.5 items-center gap-2 4k:gap-2.5 medium12 lg:flex hidden">
             <Image
               className="rounded"
@@ -160,7 +162,7 @@ const RewardCard: React.FC<RewardCardProps> = ({
               height={15}
             />
             Rewards
-          </div>
+          </div>}
         </div>
         <div className="flex lg:mt-3 items-center">
           <div className="bold33">

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -18,7 +18,6 @@ import { Button } from "antd"
 import Image from "next/image"
 import { Dispatch, SetStateAction, useState } from "react"
 import FilterBtn from "./filterBtn"
-import { StakingPoolType } from "@/misc/stakingPoolsConfig"
 import FastFadeScroll from "./FastFadeScroll"
 
 interface UnstakeCardProps {

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -55,17 +55,18 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
           />
           <div className="semi24">{stakingPool.definition.name}</div>
           <div className="text-gray4 lg:hidden text-20">|</div>
-          {stakingPool.definition.poolType != StakingPoolType.LIQUID &&
-          <div className="bg-gray4 text-white3 py-1 4k:py-1.5 px-2 4k:px-2.5 items-center gap-2 4k:gap-2.5 medium12 lg:flex hidden">
-            <Image
-              className="rounded"
-              src={requests}
-              alt="requests"
-              width={14}
-              height={15}
-            />
-            Requests
-          </div>}
+          {stakingPool.definition.poolType != StakingPoolType.LIQUID && (
+            <div className="bg-gray4 text-white3 py-1 4k:py-1.5 px-2 4k:px-2.5 items-center gap-2 4k:gap-2.5 medium12 lg:flex hidden">
+              <Image
+                className="rounded"
+                src={requests}
+                alt="requests"
+                width={14}
+                height={15}
+              />
+              Requests
+            </div>
+          )}
         </div>
         <div className="flex lg:mt-3 items-center">
           <div className="bold33">
@@ -152,17 +153,18 @@ const RewardCard: React.FC<RewardCardProps> = ({
           />
           <div className="semi24">{stakingPool.definition.name}</div>
           <div className="text-gray4 lg:hidden text-20">|</div>
-          {stakingPool.definition.poolType != StakingPoolType.LIQUID &&
-          <div className="bg-gray4 text-white3 py-1 4k:py-1.5 px-2 4k:px-2.5 items-center gap-2 4k:gap-2.5 medium12 lg:flex hidden">
-            <Image
-              className="rounded"
-              src={rewards}
-              alt="rewards"
-              width={14}
-              height={15}
-            />
-            Rewards
-          </div>}
+          {stakingPool.definition.poolType != StakingPoolType.LIQUID && (
+            <div className="bg-gray4 text-white3 py-1 4k:py-1.5 px-2 4k:px-2.5 items-center gap-2 4k:gap-2.5 medium12 lg:flex hidden">
+              <Image
+                className="rounded"
+                src={rewards}
+                alt="rewards"
+                width={14}
+                height={15}
+              />
+              Rewards
+            </div>
+          )}
         </div>
         <div className="flex lg:mt-3 items-center">
           <div className="bold33">

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -91,7 +91,7 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
           </div>
         </div>
       </div>
-      <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[218px] w-full px-3 lg:pb-0 pb-4 lg:px-4 4k:px-5">
+      <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 max-w-[218px] w-full px-3 lg:pb-0 pb-4 lg:px-4 4k:px-5">
         <div className="max-lg:w-1/2">
           <Button
             className="btn-primary-grey 4k:py-6 lg:py-5 py-4"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -279,7 +279,7 @@ const HomePage = () => {
       >
         {/* Header */}
         <div className="h-[10vh] w-full flex items-center justify-center text-white border-b-[0.5px] border-gray2">
-          <div className="flex max-w-screen-2xl w-full justify-between px-4 lg:px-8 xl:px-12 4k:px-16 max-w-screen-4k">
+          <div className="flex max-w-screen-2xl w-full justify-between px-4 lg:px-8 xl:px-12 4k:px-16 4k:max-w-screen-4k">
             <div className="flex items-center">
               <Image
                 //src="https://zil-dev.cdn.prismic.io/zil-dev/f3b97b97-e98b-4767-9b24-9474b9c20a83_Asset+1.svg"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -430,3 +430,14 @@ button,
     margin-right: 1rem;
   }
 }
+
+
+  
+  @media (max-width: 1024px) {
+.intercom-lightweight-app-launcher{
+
+    bottom: 60px !important;
+  right:10px !important;
+  }
+
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -431,13 +431,9 @@ button,
   }
 }
 
-
-  
-  @media (max-width: 1024px) {
-.intercom-lightweight-app-launcher{
-
+@media (max-width: 1024px) {
+  .intercom-lightweight-app-launcher {
     bottom: 60px !important;
-  right:10px !important;
+    right: 10px !important;
   }
-
 }


### PR DESCRIPTION
#description: 

- last transaction appears now below the stake btn with no gray bg and centered - Apt-1751
- tags (reqard - requested)  are only for non liquid claims now - APT-1758
- added unbonding period to unstake - APT-1761
- remove horizontal line from unstake - lama cmnt
- fix claim btn stretching in claim tab - lama cmnt
- fix the navbar mobile to avoid intercom overlapping - APT-1753
- add padding to the stake unstake to avoid overlapping with intercom icon - APT-1760
- fix details view when opened from a validator now shows the stake tab while when opening from claim it opens claim tab - re fix (overridden at some conflict)
- info box in Non-liquid need text needs to be centered (cols are now based on number of values) - APT-1756

#testing:

- check last transaction in stake tab in details
- check tags of claims in claims list
- check unstake tab in details for bonding value
- check claim btn in claim tab not stretching
- check mobile nav and try scrolling on different views
- try opening details from a validator vs from claims card
- check info box of non liquid validator 