### PR TITLE
APT-1762: Disable stake reward if reward lower than minimal staking value

### DIFF
--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -1,8 +1,10 @@
 import { AppConfigStorage } from "@/contexts/appConfigStorage"
 import { StakingOperations } from "@/contexts/stakingOperations"
+import { StakingPoolsStorage } from "@/contexts/stakingPoolsStorage"
 
 import {
   formatAddress,
+  formatUnitsToHumanReadable,
   getHumanFormDuration,
   getTxExplorerUrl,
 } from "@/misc/formatting"
@@ -11,7 +13,7 @@ import {
   UserNonLiquidStakingPoolRewardData,
   UserUnstakingPoolData,
 } from "@/misc/walletsConfig"
-import { Button } from "antd"
+import { Button, Tooltip } from "antd"
 import { DateTime } from "luxon"
 import Link from "next/link"
 import { formatUnits } from "viem"
@@ -40,6 +42,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
   } = StakingOperations.useContainer()
 
   const { appConfig } = AppConfigStorage.useContainer()
+  const { getMinimalPoolStakingAmount } = StakingPoolsStorage.useContainer()
 
   const pendingUnstake = userUnstakingPoolData
     ?.filter((claim) => claim.availableAt > DateTime.now())
@@ -96,13 +99,37 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
               <div className="w-[4em] h-[1em] animated-gradient" />
             )}
             <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[218px] w-full">
-              <Button
-                className="btn-secondary-grey lg:py-5 py-4 mb-2.5"
-                onClick={() => stakeReward(reward.address)}
-                loading={isStakingRewardInProgress}
-              >
-                Stake Reward
-              </Button>
+              {getMinimalPoolStakingAmount(reward.address) >
+              reward.zilRewardAmount ? (
+                <Tooltip
+                  placement="top"
+                  arrow={true}
+                  color="#555555"
+                  className="mr-1"
+                  title={`Reward is less than the minimal staking amount of ${formatUnitsToHumanReadable(
+                    getMinimalPoolStakingAmount(reward.address),
+                    18
+                  )} ZIL`}
+                >
+                  <Button
+                    className="btn-secondary-grey lg:py-5 py-4 mb-2.5"
+                    onClick={() => stakeReward(reward.address)}
+                    loading={isStakingRewardInProgress}
+                    disabled={true}
+                  >
+                    Stake Reward
+                  </Button>
+                </Tooltip>
+              ) : (
+                <Button
+                  className="btn-secondary-grey lg:py-5 py-4 mb-2.5"
+                  onClick={() => stakeReward(reward.address)}
+                  loading={isStakingRewardInProgress}
+                >
+                  Stake Reward
+                </Button>
+              )}
+
               <Button
                 className="btn-secondary-grey lg:py-5 py-4"
                 onClick={() => claimReward(reward.address)}

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -14,7 +14,7 @@ import {
   UserNonLiquidStakingPoolRewardData,
   UserUnstakingPoolData,
 } from "@/misc/walletsConfig"
-import { Button } from "antd"
+import { Button, Tooltip } from "antd"
 import Image from "next/image"
 import { Dispatch, SetStateAction, useState } from "react"
 import FilterBtn from "./filterBtn"
@@ -127,6 +127,8 @@ const RewardCard: React.FC<RewardCardProps> = ({
   stakeReward,
   setViewClaim,
 }) => {
+  const { isStakingRewardInProgress } = StakingOperations.useContainer()
+
   return (
     <div
       className="flex gap-2.5 4k:gap-4 lg:w-full max-lg:flex-col bg-aqua-gradient rounded-[20px] items-center cursor-pointer lg:justify-between"
@@ -188,17 +190,39 @@ const RewardCard: React.FC<RewardCardProps> = ({
       </div>
       <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 w-full lg:max-w-[218px] px-3 lg:pb-0 pb-4 lg:px-4 4k:px-5">
         <div className="max-lg:w-1/2">
-          <Button
-            className="btn-primary-grey 4k:py-6 lg:py-5 py-4"
-            onClick={() => stakeReward(stakingPool.definition.address)}
-          >
-            Stake Reward
-          </Button>
+          {stakingPool.definition.minimumStake > rewardInfo.zilRewardAmount ? (
+            <Tooltip
+              placement="top"
+              arrow={true}
+              color="#555555"
+              title={`Reward is less than the minimal staking amount of ${formatUnitsToHumanReadable(
+                stakingPool.definition.minimumStake,
+                18
+              )} ZIL`}
+            >
+              <Button
+                className="btn-primary-grey 4k:py-6 lg:py-5 py-4"
+                onClick={() => stakeReward(rewardInfo.address)}
+                loading={isStakingRewardInProgress}
+                disabled={true}
+              >
+                Stake Reward
+              </Button>
+            </Tooltip>
+          ) : (
+            <Button
+              className="btn-primary-grey 4k:py-6 lg:py-5 py-4"
+              onClick={() => stakeReward(rewardInfo.address)}
+              loading={isStakingRewardInProgress}
+            >
+              Stake Reward
+            </Button>
+          )}
         </div>
         <div className="max-lg:w-1/2 lg:mt-2.5">
           <Button
             className="btn-secondary-grey 4k:py-6 lg:py-5 py-4"
-            onClick={() => claimReward(stakingPool.definition.address)}
+            onClick={() => claimReward(rewardInfo.address)}
           >
             Claim Reward
           </Button>

--- a/src/contexts/stakingPoolsStorage.tsx
+++ b/src/contexts/stakingPoolsStorage.tsx
@@ -232,6 +232,18 @@ const useStakingPoolsStorage = () => {
     (unstakeData) => unstakeData.unstakeInfo.availableAt > DateTime.now()
   )
 
+  const getMinimalPoolStakingAmount = (stakinPoolAddress: string) => {
+    const stakingPoolData = availableStakingPoolsData.find(
+      (pool) => pool.definition.address === stakinPoolAddress
+    )
+
+    if (!stakingPoolData) {
+      throw new Error("Staking pool not found") // this means that config is invalid
+    }
+
+    return stakingPoolData.definition.minimumStake
+  }
+
   return {
     availableStakingPools: availableStakingPoolsData,
     stakingPoolForView: combinedSelectedStakingPoolForViewData,
@@ -243,6 +255,7 @@ const useStakingPoolsStorage = () => {
     nonLiquidRewards: combinedUserNonLiquidPoolRewards,
     reloadUserStakingPoolsData,
     isUnstakingDataLoading,
+    getMinimalPoolStakingAmount,
   }
 }
 

--- a/src/misc/walletsConfig.ts
+++ b/src/misc/walletsConfig.ts
@@ -142,7 +142,7 @@ export const dummyWallets: Array<DummyWallet> = [
     unstakingEntries: [
       {
         address: "0x96525678902345678902345678918278372212",
-        zilAmount: parseUnits("100", 18),
+        zilAmount: parseUnits("89", 18),
         availableAt: DateTime.now().plus({ days: 5 }),
       },
       {
@@ -178,7 +178,12 @@ export const dummyWallets: Array<DummyWallet> = [
       },
     ],
     unstakingEntries: [],
-    nonLiquidRewards: [],
+    nonLiquidRewards: [
+      {
+        address: "0xe863906941de820bde06701a0d804dd0b8575d67",
+        zilRewardAmount: parseUnits("1000", 18),
+      },
+    ],
   },
 ]
 


### PR DESCRIPTION
# Description

Disabled the stake reward button with a tooltip if the reward was too low for staking.
<img width="989" alt="Screenshot 2025-02-19 at 09 51 01" src="https://github.com/user-attachments/assets/3e2e8ff3-b080-4496-bdeb-e2e3f748da4c" />

# Testing

Tested with mocked wallet. `Some ZIL, some ZIL staked on non-liquid` has reward stake disabled with a tooltip. `No Zil, Some ZIL staked, No ZIL unstaked` has a reward that is available for re-staking. 