### PR TITLE
APT-1765: Stake guardrails

### DIFF
--- a/src/components/customWalletConnect.tsx
+++ b/src/components/customWalletConnect.tsx
@@ -1,11 +1,10 @@
 import { AppConfigStorage } from "@/contexts/appConfigStorage"
 import { WalletConnector } from "@/contexts/walletConnector"
 import { MOCK_CHAIN } from "@/misc/chainConfig"
-import { formatAddress } from "@/misc/formatting"
+import { formatAddress, formatUnitsToHumanReadable } from "@/misc/formatting"
 import { WalletOutlined } from "@ant-design/icons"
 import { ConnectButton } from "@rainbow-me/rainbowkit"
 import { Button } from "antd"
-import { useMemo } from "react"
 
 /**
  * notConnectedClassName will be used for other cases if if connectedClassName or wrongNetworkClassName is not provided
@@ -31,6 +30,7 @@ const CustomWalletConnect: React.FC<CustomWalletConnectProps> = ({
     disconnectDummyWallet,
     isDummyWalletConnected,
     walletAddress,
+    zilAvailable,
   } = WalletConnector.useContainer()
 
   if (appConfig.chainId === MOCK_CHAIN.id) {
@@ -54,7 +54,8 @@ const CustomWalletConnect: React.FC<CustomWalletConnectProps> = ({
         >
           <div className=" group-hover:hidden transition-opacity flex items-center justify-center">
             <WalletOutlined className="mr-2 !text-black-100" />
-            {formatAddress(walletAddress || "")}
+            {formatAddress(walletAddress || "")} |{" "}
+            {formatUnitsToHumanReadable(zilAvailable || 0n, 18)} ZIL
           </div>
           <span className=" !hidden group-hover:!block transition-opacity  items-center justify-center">
             Disconnect


### PR DESCRIPTION
# Description

`Stake` button is now properly disabled and informs user why it is disabled by tooltip. Example

<img width="989" alt="Screenshot 2025-02-19 at 11 37 05" src="https://github.com/user-attachments/assets/d2984272-3b84-4da4-9ca0-e1942046feb8" />

# Testing

Tested locally with mocked wallet, and stake button responses are correct.  