### PR TITLE
APT-1813: Max button now takes fees into the account

### DIFF
--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -120,7 +120,12 @@ const StakingCalculator: React.FC = () => {
   }
 
   const onMaxClick = () => {
-    setZilToStake(`${formatUnits(zilAvailable || 0n, 18)}`)
+    const allZil = formatUnits(zilAvailable || 0n, 18)
+    const roundedToNiceNumber = allZil.split(".")[0]
+    const availableMinusFees =
+      parseFloat(roundedToNiceNumber) - stakingTxCostInZill
+
+    setZilToStake(`${availableMinusFees}`)
   }
 
   const isPoolLiquid = () =>


### PR DESCRIPTION
# Description

Without this, clicking `Max` on staking will always prevent people from staking, as there is no ZIL left for fees.

# Testing

Works nicely locally.