### PR TITLE
APT-1819, APT-1830: Unstaking panel improvements

### DIFF
--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -9,7 +9,7 @@ import {
   getTxExplorerUrl,
   formatAddress,
 } from "@/misc/formatting"
-import { formatUnits, parseEther } from "viem"
+import { formatUnits, parseEther, parseUnits } from "viem"
 import { StakingOperations } from "@/contexts/stakingOperations"
 import { DateTime } from "luxon"
 import { StakingPoolType } from "@/misc/stakingPoolsConfig"
@@ -21,9 +21,7 @@ import { AppConfigStorage } from "@/contexts/appConfigStorage"
 
 const UnstakingCalculator: React.FC = () => {
   const { appConfig } = AppConfigStorage.useContainer()
-
   const { isWalletConnected } = WalletConnector.useContainer()
-
   const { stakingPoolForView } = StakingPoolsStorage.useContainer()
 
   const {
@@ -33,7 +31,16 @@ const UnstakingCalculator: React.FC = () => {
     unstakeContractCallError,
   } = StakingOperations.useContainer()
 
-  const [zilToUnstake, setZilToUnstake] = useState<string>("0")
+  const [tokensToUnstake, setZilToUnstake] = useState<string>("0")
+
+  const stakedTokenAvailable =
+    stakingPoolForView?.userData?.staked?.stakingTokenAmount || 0n
+  const poolTokenDecimals =
+    stakingPoolForView?.stakingPool.definition.tokenDecimals || 18
+
+  const onMaxClick = () => {
+    setZilToUnstake(`${formatUnits(stakedTokenAvailable, poolTokenDecimals)}`)
+  }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value: inputValue } = e.target
@@ -44,45 +51,31 @@ const UnstakingCalculator: React.FC = () => {
   }
 
   const handleFocus = () => {
-    if (zilToUnstake === "") onMaxClick()
+    if (tokensToUnstake === "") onMaxClick()
   }
 
   const handleBlur = () => {
-    let valueTemp = zilToUnstake
+    let valueTemp = tokensToUnstake
     if (
-      zilToUnstake.charAt(zilToUnstake.length - 1) === "." ||
-      zilToUnstake === "-"
+      tokensToUnstake.charAt(tokensToUnstake.length - 1) === "." ||
+      tokensToUnstake === "-"
     ) {
-      valueTemp = zilToUnstake.slice(0, -1)
+      valueTemp = tokensToUnstake.slice(0, -1)
     }
     setZilToUnstake(valueTemp.replace(/0*(\d+)/, "$1"))
-    if (zilToUnstake === "") onMaxClick()
+    if (tokensToUnstake === "") onMaxClick()
   }
 
   useEffect(() => {
-    setZilToUnstake("1")
-  }, [stakingPoolForView])
+    if (stakingPoolForView?.userData) {
+      onMaxClick()
+    }
+  }, [stakingPoolForView?.userData])
 
-  const stakedTokenAvailable =
-    stakingPoolForView?.userData?.staked?.stakingTokenAmount || 0
-
-  const zilToUnstakeNumber = parseFloat(zilToUnstake)
-  const zilInWei = parseEther(zilToUnstake)
-  const zilToUnstakeOk =
-    !isNaN(zilToUnstakeNumber) && zilToUnstakeNumber <= stakedTokenAvailable
-  const canUnstake =
-    stakingPoolForView?.stakingPool.data &&
-    zilToUnstakeNumber > 0 &&
-    zilToUnstakeNumber <= stakedTokenAvailable
-
-  const onMaxClick = () => {
-    setZilToUnstake(
-      `${formatUnits(
-        stakingPoolForView?.userData?.staked?.stakingTokenAmount || 0n,
-        stakingPoolForView?.stakingPool.definition.tokenDecimals || 18
-      )}`
-    )
-  }
+  const tokenToUnstakeInBaseUnit = parseUnits(
+    tokensToUnstake,
+    poolTokenDecimals
+  )
 
   const unboudingPeriod = getHumanFormDuration(
     DateTime.now().plus({
@@ -95,6 +88,40 @@ const UnstakingCalculator: React.FC = () => {
     stakingPoolForView?.stakingPool.definition.poolType ===
     StakingPoolType.LIQUID
 
+  const isUnstakingAvailable =
+    (stakingPoolForView?.userData.staked?.stakingTokenAmount || 0n) !== 0n
+
+  const { canUnstake, whyCantUnstake } = (() => {
+    if (!stakingPoolForView?.stakingPool.data) {
+      return {
+        canUnstake: false,
+        whyCantUnstake: "Loading staking data",
+      }
+    } else if (!isUnstakingAvailable) {
+      return {
+        canUnstake: false,
+        whyCantUnstake: "No staked balance",
+      }
+    } else if (tokenToUnstakeInBaseUnit <= 0n) {
+      return {
+        canUnstake: false,
+        whyCantUnstake: "Enter a valid amount",
+      }
+    } else if (stakedTokenAvailable < tokenToUnstakeInBaseUnit) {
+      return {
+        canUnstake: false,
+        whyCantUnstake: "Insufficient staked balance",
+      }
+    } else {
+      return {
+        canUnstake: true,
+        whyCantUnstake: "Send an unstake transaction",
+      }
+    }
+  })()
+
+  console.log(isUnstakingAvailable)
+
   return (
     stakingPoolForView && (
       <FastFadeScroll
@@ -104,16 +131,20 @@ const UnstakingCalculator: React.FC = () => {
         <div className="flex justify-between gap-10 4k:gap-14 my-2.5 lg:my-4 4k:my-6 p-3 lg:p-5 xl:p-7 4k:p-10 bg-grey-gradient rounded-xl items-center">
           <div className="h-fit self-center">
             <Input
-              className="flex items-baseline !bg-transparent !border-transparent !text-white1 bold33 px-0"
-              //    ${
-              //   zilToUnstakeOk ? '!text-white1' : '!text-red1'
-              // }
-              value={zilToUnstake}
+              className={`flex items-baseline !bg-transparent !border-transparent bold33 px-0 ${isUnstakingAvailable ? "!text-white1" : "!text-gray-500"}`}
+              value={tokensToUnstake}
               onChange={handleChange}
               onBlur={handleBlur}
               onFocus={handleFocus}
-              prefix={stakingPoolForView.stakingPool.definition.tokenSymbol}
-              status={!zilToUnstakeOk ? "error" : undefined}
+              prefix={
+                <div
+                  className={`${isUnstakingAvailable ? "!text-white1" : "!text-gray-500"}`}
+                >
+                  {stakingPoolForView.stakingPool.definition.tokenSymbol}
+                </div>
+              }
+              status={!canUnstake ? "error" : undefined}
+              disabled={!isUnstakingAvailable}
             />
             <div className="flex items-center ">
               {isPoolLiquid() && (
@@ -123,7 +154,7 @@ const UnstakingCalculator: React.FC = () => {
                       ~
                       {formatUnitsToHumanReadable(
                         convertTokenToZil(
-                          zilInWei,
+                          tokenToUnstakeInBaseUnit,
                           stakingPoolForView.stakingPool.data.zilToTokenRate
                         ),
                         18
@@ -137,10 +168,7 @@ const UnstakingCalculator: React.FC = () => {
               )}
               <span
                 className={`${
-                  stakingPoolForView?.stakingPool.definition.poolType ===
-                  StakingPoolType.LIQUID
-                    ? "text-aqua1"
-                    : "text-purple3"
+                  isPoolLiquid() ? "text-aqua1" : "text-purple3"
                 } medium17 ml-2 `}
               >
                 {unboudingPeriod}
@@ -151,12 +179,14 @@ const UnstakingCalculator: React.FC = () => {
             <Button
               className="btn-secondary-colored text-aqua1 hover:!text-aqua1 border-0 bg-tealDark hover:!bg-tealDark"
               onClick={onMaxClick}
+              disabled={!isUnstakingAvailable}
             >
               MAX
             </Button>
             <Button
               className="btn-secondary-colored text-purple3 hover:!text-purple1 border-0 bg-PurpleDarker hover:!bg-PurpleDarker"
               onClick={() => setZilToUnstake("1")}
+              disabled={!isUnstakingAvailable}
             >
               MIN
             </Button>
@@ -166,26 +196,32 @@ const UnstakingCalculator: React.FC = () => {
         <div className="flex flex-col justify-between">
           <div className="flex mt-2 mb-3">
             {isWalletConnected ? (
-              <Button
-                type="default"
-                size="large"
-                className={`${
-                  stakingPoolForView?.stakingPool.definition.poolType ===
-                  StakingPoolType.LIQUID
-                    ? "btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua"
-                    : "btn-primary-gradient-purple-lg lg:btn-primary-gradient-purple"
-                }  mx-auto lg:w-1/2 w-2/3`}
-                disabled={!canUnstake}
-                onClick={() =>
-                  unstake(
-                    stakingPoolForView.stakingPool.definition.address,
-                    zilInWei
-                  )
-                }
-                loading={isUnstakingInProgress}
+              <Tooltip
+                placement="top"
+                arrow={true}
+                color="#555555"
+                title={whyCantUnstake}
               >
-                Unstake
-              </Button>
+                <Button
+                  type="default"
+                  size="large"
+                  className={`${
+                    isPoolLiquid()
+                      ? "btn-primary-gradient-aqua-lg lg:btn-primary-gradient-aqua"
+                      : "btn-primary-gradient-purple-lg lg:btn-primary-gradient-purple"
+                  }  mx-auto lg:w-1/2 w-2/3`}
+                  disabled={!canUnstake}
+                  onClick={() =>
+                    unstake(
+                      stakingPoolForView.stakingPool.definition.address,
+                      tokenToUnstakeInBaseUnit
+                    )
+                  }
+                  loading={isUnstakingInProgress}
+                >
+                  Unstake
+                </Button>
+              </Tooltip>
             ) : (
               <CustomWalletConnect notConnectedClassName="btn-primary-gradient-aqua sm:px-10 sm:max-w-fit  mx-auto lg:w-1/2 w-2/3">
                 Connect wallet
@@ -227,12 +263,7 @@ const UnstakingCalculator: React.FC = () => {
               </div>
               <div className="">Max transaction cost: 3 ZIL</div>
               <div
-                className={`${
-                  stakingPoolForView?.stakingPool.definition.poolType ===
-                  StakingPoolType.LIQUID
-                    ? "text-aqua1"
-                    : "text-purple3"
-                } `}
+                className={`${isPoolLiquid() ? "text-aqua1" : "text-purple3"} `}
               >
                 Unbonding Period: {unboudingPeriod}
               </div>


### PR DESCRIPTION
# Description

- The unstaking panel controls are disabled if user has no staked tokens in the given pool
- guardrails for `unstake` button added, similarly as for `staking`

# Testing

Tested with mocked wallet. The unstaking panel does not allow values that will obviously fail. Also, it is properly disabled when no staked tokens are present.