### PR TITLE
APT-1841: State messages on buttons

### DIFF
--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -27,6 +27,7 @@ const StakingCalculator: React.FC = () => {
   const { zilAvailable } = WalletConnector.useContainer()
   const {
     stake,
+    preparingStakingTx,
     isStakingInProgress,
     stakingCallTxHash,
     stakeContractCallError,
@@ -279,7 +280,11 @@ ${
                       }
                       loading={isStakingInProgress}
                     >
-                      Stake
+                      {preparingStakingTx
+                        ? "Confirm in wallet"
+                        : isStakingInProgress
+                          ? "Processing"
+                          : "Stake"}
                     </Button>
                   ) : (
                     <Tooltip

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -34,6 +34,7 @@ const UnstakingCalculator: React.FC = () => {
     unstakingCallTxHash,
     unstakeContractCallError,
     unstakingCallZilFees,
+    preparingUnstakingTx,
   } = StakingOperations.useContainer()
 
   const [tokensToUnstake, setZilToUnstake] = useState<string>("0")
@@ -262,7 +263,11 @@ ${
                   }
                   loading={isUnstakingInProgress}
                 >
-                  Unstake
+                  {preparingUnstakingTx
+                    ? "Confirm in wallet"
+                    : isUnstakingInProgress
+                      ? "Processing"
+                      : "Unstake"}
                 </Button>
               </Tooltip>
             ) : (

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -33,12 +33,15 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
     claimUnstake,
     isClaimingUnstakeInProgress,
     claimUnstakeCallTxHash,
+    preparingClaimUnstakeTx,
     claimReward,
     isClaimingRewardInProgress,
     claimRewardCallTxHash,
+    preparingClaimRewardTx,
     stakeReward,
     isStakingRewardInProgress,
     stakeRewardCallTxHash,
+    preparingStakeRewardTx,
   } = StakingOperations.useContainer()
 
   const { appConfig } = AppConfigStorage.useContainer()
@@ -134,7 +137,11 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
                   onClick={() => stakeReward(reward.address)}
                   loading={isStakingRewardInProgress}
                 >
-                  Stake Reward
+                  {preparingStakeRewardTx
+                    ? "Confirm in wallet"
+                    : isStakingRewardInProgress
+                      ? "Processing"
+                      : "Stake Reward"}
                 </Button>
               )}
 
@@ -143,7 +150,11 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
                 onClick={() => claimReward(reward.address)}
                 loading={isClaimingRewardInProgress}
               >
-                Claim Reward
+                {preparingClaimRewardTx
+                  ? "Confirm in wallet"
+                  : isClaimingRewardInProgress
+                    ? "Processing"
+                    : "Claim Reward"}
               </Button>
             </div>
           </div>
@@ -185,7 +196,11 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
                   onClick={() => claimUnstake(item.address)}
                   loading={isClaimingUnstakeInProgress}
                 >
-                  Claim
+                  {preparingClaimUnstakeTx
+                    ? "Confirm in wallet"
+                    : isClaimingUnstakeInProgress
+                      ? "Processing"
+                      : "Claim"}
                 </Button>
               </div>
             </div>

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -37,6 +37,9 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
   claimUnstake,
   setViewClaim,
 }) => {
+  const { preparingClaimUnstakeTx, isClaimingUnstakeInProgress } =
+    StakingOperations.useContainer()
+
   return (
     <div
       className={` ${stakingPool.definition.poolType != StakingPoolType.LIQUID ? "purple-border-bottom" : "aqua-border-bottom"}  flex gap-2.5 4k:gap-3 lg:w-full max-lg:flex-col bg-aqua-gradient rounded-[20px] items-center cursor-pointer lg:justify-between`}
@@ -102,9 +105,14 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
             className="btn-primary-grey 4k:py-6 lg:py-5 py-4"
             disabled={!available}
             onClick={() => claimUnstake(unstakeInfo.address)}
+            loading={isClaimingUnstakeInProgress}
           >
             {available
-              ? "Claim"
+              ? preparingClaimUnstakeTx
+                ? "Confirm in wallet"
+                : isClaimingUnstakeInProgress
+                  ? "Processing"
+                  : "Claim"
               : getHumanFormDuration(unstakeInfo.availableAt) + " left"}
           </Button>
         </div>
@@ -130,7 +138,12 @@ const RewardCard: React.FC<RewardCardProps> = ({
   stakeReward,
   setViewClaim,
 }) => {
-  const { isStakingRewardInProgress } = StakingOperations.useContainer()
+  const {
+    isStakingRewardInProgress,
+    preparingStakeRewardTx,
+    isClaimingRewardInProgress,
+    preparingClaimRewardTx,
+  } = StakingOperations.useContainer()
 
   return (
     <div
@@ -213,16 +226,25 @@ const RewardCard: React.FC<RewardCardProps> = ({
               onClick={() => stakeReward(rewardInfo.address)}
               loading={isStakingRewardInProgress}
             >
-              Stake Reward
+              {preparingStakeRewardTx
+                ? "Confirm in wallet"
+                : isStakingRewardInProgress
+                  ? "Processing"
+                  : "Stake Reward"}
             </Button>
           )}
         </div>
         <div className="max-lg:w-1/2 lg:mt-2.5">
           <Button
             className="btn-secondary-grey 4k:py-6 lg:py-5 py-4"
+            loading={isClaimingRewardInProgress}
             onClick={() => claimReward(rewardInfo.address)}
           >
-            Claim Reward
+            {preparingClaimRewardTx
+              ? "Confirm in wallet"
+              : isClaimingRewardInProgress
+                ? "Processing"
+                : "Claim Reward"}
           </Button>
         </div>
       </div>

--- a/src/contexts/stakingOperations.tsx
+++ b/src/contexts/stakingOperations.tsx
@@ -113,7 +113,7 @@ const useTxOperation = (
   }
 
   return {
-    isTxInPreparation,
+    isTxInPreparation: isTxInPreparation || txSubmissionStatus === "pending",
     isTxProcessedByChain,
     txHash,
     txContractError,
@@ -359,18 +359,21 @@ const useStakingOperations = () => {
     setIsDummyWalletPopupOpen,
 
     stake,
+    preparingStakingTx,
     isStakingInProgress: submittingStakingTx || preparingStakingTx,
     stakingCallTxHash,
     stakeContractCallError,
     stakingCallZilFees: getGasCostInZil(stakingCallEstimatedGas),
 
     unstake,
+    preparingUnstakingTx,
     isUnstakingInProgress: submittingUnstakingTx || preparingUnstakingTx,
     unstakingCallTxHash,
     unstakeContractCallError,
     unstakingCallZilFees: getGasCostInZil(unstakingCallEstimatedGas),
 
     claimUnstake,
+    preparingClaimUnstakeTx,
     isClaimingUnstakeInProgress:
       submittingClaimUnstakeTx || preparingClaimUnstakeTx,
     claimUnstakeCallTxHash,
@@ -378,6 +381,7 @@ const useStakingOperations = () => {
     claimUnstakeCallZilFees: getGasCostInZil(claimUnstakingCallEstimatedGas),
 
     claimReward,
+    preparingClaimRewardTx,
     isClaimingRewardInProgress:
       submittingClaimRewardTx || preparingClaimRewardTx,
     claimRewardCallTxHash,
@@ -385,6 +389,7 @@ const useStakingOperations = () => {
     claimRewardCallZilFees: getGasCostInZil(claimRewardCallEstimatedGas),
 
     stakeReward,
+    preparingStakeRewardTx,
     isStakingRewardInProgress:
       submittingStakeRewardTx || preparingStakeRewardTx,
     stakeRewardCallTxHash,


### PR DESCRIPTION
# Description

This PR adds a "Confirm in wallet" and "Processing" texts to all blockchain action buttons. States are shown instead of default button text depending on the tx state.
Additionally, some buttons had no `loading` flag hooked up, so I fixed that.

# Testing

Tested locally by staking and going through app, works fine. 