### PR TITLE
APT-1841: Auto refreshing remaining time for unstake and reward

### DIFF
--- a/src/contexts/stakingPoolsStorage.tsx
+++ b/src/contexts/stakingPoolsStorage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { createContainer } from "./context"
 import { WalletConnector } from "./walletConnector"
 import { DateTime } from "luxon"
@@ -97,6 +97,23 @@ const useStakingPoolsStorage = () => {
     useState<StakingPool | null>(null)
 
   const [isUnstakingDataLoading, setIsUnstakingDataLoading] = useState(false)
+
+  /**
+   * This interval forces rerender and state recalculation for subset of items
+   * that have availableAt property. This is done by simply copying such state.
+   * This methid is cheap and does not require any additional API calls.
+   * This makes the frontend to properly display the time left and availability
+   * for such items
+   */
+  const _refreshItemsWithAvailableAt = useMemo(
+    () =>
+      setInterval(() => {
+        console.log("Refreshing unstakings")
+        setUserUnstakesData((current) => [...current])
+        setUserNonLiquidPoolRewards((current) => [...current])
+      }, 5000),
+    []
+  )
 
   const reloadUserStakingPoolsData = () => {
     if (!walletAddress) {

--- a/src/misc/formatting.ts
+++ b/src/misc/formatting.ts
@@ -37,7 +37,11 @@ export function getHumanFormDuration(availableAt: DateTime) {
       return acc
     }, "")
 
-  return `~${mostSignificantUnit || "< 1 minute"}`
+  if (mostSignificantUnit === "") {
+    return "< 1 minute"
+  } else {
+    return `~${mostSignificantUnit}`
+  }
 }
 
 export function convertTokenToZil(

--- a/src/misc/walletsConfig.ts
+++ b/src/misc/walletsConfig.ts
@@ -366,9 +366,13 @@ export async function getWalletUnstakingData(
             ...uwd.blockNumberAndAmount.map((bna) => {
               const blocksRemaining = Number(bna[0] - currentBlockNumber)
 
+              const blocksRemainingInSeconds = blocksRemaining * 1 // seconds per block
+
               return {
                 zilAmount: bna[1],
-                availableAt: DateTime.now().plus({ seconds: blocksRemaining }), // we assume block takes a second
+                availableAt: DateTime.now().plus({
+                  seconds: blocksRemainingInSeconds,
+                }),
                 address: uwd.address,
               }
             })


### PR DESCRIPTION
# Description

This PR makes the `time left` information on pending `stake` and `reward` components update on its own as time goes on.

# Testing

I unstaked some of tokens. Then I went to claim and checked that the time went down without refreshing the page. Also, when the claim becomes available, it automatically updates the claim tab with a new total sum available for withdrawal.