### PR TITLE
APT-1777: claims btns handle

### DIFF
--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -101,7 +101,11 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
           <Button
             className="btn-primary-grey 4k:py-6 lg:py-5 py-4"
             disabled={!available}
-            onClick={() => claimUnstake(unstakeInfo.address)}
+            onClick={(e) => {
+              e.stopPropagation()
+              claimUnstake(unstakeInfo.address)
+              setViewClaim(false)
+            }}
           >
             {available
               ? "Claim"
@@ -200,7 +204,11 @@ const RewardCard: React.FC<RewardCardProps> = ({
             >
               <Button
                 className="btn-primary-grey 4k:py-6 lg:py-5 py-4"
-                onClick={() => stakeReward(rewardInfo.address)}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  stakeReward(rewardInfo.address)
+                  setViewClaim(false)
+                }}
                 loading={isStakingRewardInProgress}
                 disabled={true}
               >
@@ -210,7 +218,11 @@ const RewardCard: React.FC<RewardCardProps> = ({
           ) : (
             <Button
               className="btn-primary-grey 4k:py-6 lg:py-5 py-4"
-              onClick={() => stakeReward(rewardInfo.address)}
+              onClick={(e) => {
+                e.stopPropagation()
+                stakeReward(rewardInfo.address)
+                setViewClaim(false)
+              }}
               loading={isStakingRewardInProgress}
             >
               Stake Reward
@@ -220,7 +232,11 @@ const RewardCard: React.FC<RewardCardProps> = ({
         <div className="max-lg:w-1/2 lg:mt-2.5">
           <Button
             className="btn-secondary-grey 4k:py-6 lg:py-5 py-4"
-            onClick={() => claimReward(rewardInfo.address)}
+            onClick={(e) => {
+              e.stopPropagation()
+              claimReward(rewardInfo.address)
+              setViewClaim(false)
+            }}
           >
             Claim Reward
           </Button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -74,7 +74,7 @@ const HomePage = () => {
       {!isWalletConnected && !stakingPoolForView ? (
         <LoginView />
       ) : stakingPoolForView ? (
-        <div className="bg-black4/[68%] rounded-2.5xl xs:px-5 lg:px-7.5 4k:px-10 h-full">
+        <div className="bg-black4/[68%] 4k:rounded-2.5xl rounded-t-2.5xl xs:px-5 lg:px-7.5 4k:px-10 h-full">
           <StakingPoolDetailsView
             stakingPoolData={stakingPoolForView.stakingPool}
             userStakingPoolData={stakingPoolForView.userData.staked}
@@ -376,7 +376,7 @@ const HomePage = () => {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 4k:gap-14 h-full max-lg:pb-16">
             {/* Left column */}
             <div
-              className={`lg:bg-white/[9%] p-4 xs:p-6 4k:p-10 max-4k:rounded-s-none rounded-2.5xl ${mobileOverlayContent && "max-lg:hidden"} overflow-hidden h-full flex flex-col `}
+              className={`lg:bg-white/[9%] p-4 xs:p-6 4k:p-10 max-4k:rounded-s-none rounded-t-2.5xl ${mobileOverlayContent && "max-lg:hidden"} overflow-hidden h-full flex flex-col `}
             >
               <StakingPoolsList
                 selectedPoolType={selectedPoolType}


### PR DESCRIPTION
#description: the btns on claim cards no longer show the details view

#description: try using the btns in the claims view on the cards: clicking on claim button should not open validator card, only clicking on whole container opens the validator card