### PR TITLE
APT-1847: Improved buttons in progress state

### DIFF
--- a/src/components/stakingPoolDetailsView.tsx
+++ b/src/components/stakingPoolDetailsView.tsx
@@ -84,6 +84,7 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
     tooltip: string | JSX.Element | null
   ) => (
     <Tooltip
+      key={title}
       placement="top"
       arrow={true}
       overlayClassName="custom-tooltip"
@@ -111,16 +112,14 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
     tooltip: string | JSX.Element | null
   ) => (
     <Tooltip
+      key={title}
       placement="top"
       arrow={true}
       overlayClassName="custom-tooltip"
       className=""
       title={tooltip}
     >
-      <div
-        key={title}
-        className={`  ${isPoolLiquid() ? "lg:w-1/4 w-1/2" : "w-1/3"} `}
-      >
+      <div className={`  ${isPoolLiquid() ? "lg:w-1/4 w-1/2" : "w-1/3"} `}>
         {value ? (
           <div className="semi14 text-gray7 xl:whitespace-nowrap">{value}</div>
         ) : (

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -118,7 +118,7 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
               claimUnstake(unstakeInfo.address)
               setViewClaim(false)
             }}
-            loading={isInProgress}
+            loading={isInProgress && available}
           >
             {available
               ? preparingClaimUnstakeTx && isCurrentWalletOperationAboutThisPool

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -37,8 +37,16 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
   claimUnstake,
   setViewClaim,
 }) => {
-  const { preparingClaimUnstakeTx, isClaimingUnstakeInProgress } =
-    StakingOperations.useContainer()
+  const {
+    preparingClaimUnstakeTx,
+    isClaimingUnstakeInProgress,
+    stakingPoolIdForInProgressOperation,
+  } = StakingOperations.useContainer()
+
+  const isCurrentWalletOperationAboutThisPool =
+    stakingPoolIdForInProgressOperation === stakingPool.definition.id
+  const isInProgress =
+    isClaimingUnstakeInProgress && isCurrentWalletOperationAboutThisPool
 
   return (
     <div
@@ -103,13 +111,6 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
         <div className="max-lg:w-1/2">
           <Button
             className={` 
-              ${
-                isClaimingUnstakeInProgress
-                  ? stakingPool.definition.poolType === StakingPoolType.LIQUID
-                    ? "liquid-loading"
-                    : "non-liquid-loading"
-                  : ""
-              }
               ${stakingPool.definition.poolType === StakingPoolType.LIQUID ? " liquid-hover" : " non-liquid-hover"} btn-primary-grey 4k:py-6 lg:py-5 py-4`}
             disabled={!available}
             onClick={(e) => {
@@ -117,12 +118,12 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
               claimUnstake(unstakeInfo.address)
               setViewClaim(false)
             }}
-            loading={isClaimingUnstakeInProgress}
+            loading={isInProgress}
           >
             {available
-              ? preparingClaimUnstakeTx
+              ? preparingClaimUnstakeTx && isCurrentWalletOperationAboutThisPool
                 ? "Confirm in wallet"
-                : isClaimingUnstakeInProgress
+                : isInProgress
                   ? "Processing"
                   : "Claim"
               : getHumanFormDuration(unstakeInfo.availableAt) + " left"}
@@ -155,7 +156,16 @@ const RewardCard: React.FC<RewardCardProps> = ({
     preparingStakeRewardTx,
     isClaimingRewardInProgress,
     preparingClaimRewardTx,
+    stakingPoolIdForInProgressOperation,
   } = StakingOperations.useContainer()
+
+  const isCurrentWalletOperationAboutThisPool =
+    stakingPoolIdForInProgressOperation === stakingPool.definition.id
+
+  const isClaimRewardInProgress =
+    isClaimingRewardInProgress && isCurrentWalletOperationAboutThisPool
+  const isStakeRewardInProgress =
+    isStakingRewardInProgress && isCurrentWalletOperationAboutThisPool
 
   return (
     <div
@@ -248,7 +258,7 @@ const RewardCard: React.FC<RewardCardProps> = ({
             <Button
               className={` 
                 ${
-                  isStakingRewardInProgress
+                  isStakeRewardInProgress
                     ? stakingPool.definition.poolType === StakingPoolType.LIQUID
                       ? "liquid-loading"
                       : "non-liquid-loading"
@@ -260,11 +270,11 @@ const RewardCard: React.FC<RewardCardProps> = ({
                 stakeReward(rewardInfo.address)
                 setViewClaim(false)
               }}
-              loading={isStakingRewardInProgress}
+              loading={isStakeRewardInProgress}
             >
               {preparingStakeRewardTx
                 ? "Confirm in wallet"
-                : isStakingRewardInProgress
+                : isStakeRewardInProgress
                   ? "Processing"
                   : "Stake Reward"}
             </Button>
@@ -274,7 +284,7 @@ const RewardCard: React.FC<RewardCardProps> = ({
           <Button
             className={`
                ${
-                 isClaimingRewardInProgress
+                 isClaimRewardInProgress
                    ? stakingPool.definition.poolType === StakingPoolType.LIQUID
                      ? "liquid-loading"
                      : "non-liquid-loading"
@@ -287,11 +297,11 @@ const RewardCard: React.FC<RewardCardProps> = ({
               claimReward(rewardInfo.address)
               setViewClaim(false)
             }}
-            loading={isClaimingRewardInProgress}
+            loading={isClaimRewardInProgress}
           >
             {preparingClaimRewardTx
               ? "Confirm in wallet"
-              : isClaimingRewardInProgress
+              : isClaimRewardInProgress
                 ? "Processing"
                 : "Claim Reward"}
           </Button>

--- a/src/misc/walletsConfig.ts
+++ b/src/misc/walletsConfig.ts
@@ -254,7 +254,12 @@ export const dummyWallets: Array<DummyWallet> = [
         availableAt: DateTime.now().minus({ days: 1 }),
       },
     ],
-    nonLiquidRewards: [],
+    nonLiquidRewards: [
+      {
+        address: "0xe863906941de820bde06701a0d804dd0b8575d67",
+        zilRewardAmount: parseUnits("1000.2", 18),
+      },
+    ],
   },
 ]
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -403,10 +403,12 @@ const HomePage = () => {
           title="User Wallet Interaction"
           open={isDummyWalletPopupOpen}
           okButtonProps={{ className: "btn-primary-cyan" }}
-          onOk={() => setIsDummyWalletPopupOpen(false)}
-          onCancel={() => setIsDummyWalletPopupOpen(false)}
+          okText="Confirm tx"
+          cancelText="Cancel"
+          onOk={dummyWalletPopupContent?.onOk}
+          onCancel={dummyWalletPopupContent?.onCancel}
         >
-          <div>{dummyWalletPopupContent}</div>
+          <div>{dummyWalletPopupContent?.content}</div>
         </Modal>
       </div>
     </>


### PR DESCRIPTION
# Description

Now only the clicked button will get into the `in progress` state. Other buttons will stay as they are. 

Other changes are:
- mocked wallet now triggers 'Success' and 'Error' notifications after closing the mocked wallet operation popup 
- missing `key` prop added to tooltips


# Testing

Tested the main page with mocked wallet 7, only the clicked button gets into the 'in progress' state.
Tested with the devnet, app works fine on that as well.