### PR TITLE
APT-1857 - APT-1852  inputs - APT-1859 btns width + minor fixes

### DIFF
--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -165,9 +165,8 @@ const StakingCalculator: React.FC = () => {
           >
             <div
               className={`transition-all duration-300 border-transparent bg-gray-gradient
-              ${
-              (  isWalletConnected || parseEther(minValue) < (zilAvailable || 0n) ) &&
-                `  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
+              ${  isWalletConnected &&
+                ` ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
                   ${isMaxValue && "bg-teal-gradient !border-teal"}
                   ${isMaxHovered && "!bg-teal-gradient"}
                   ${isMinValue && "bg-purple-gradient"}
@@ -179,7 +178,7 @@ const StakingCalculator: React.FC = () => {
                 <div className=" flex items-center gap-2">
                   <div
                     className={`${
-                      !isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) ? "text-gray4" : "text-white1"
+                      !isWalletConnected ? "text-gray4" : "text-white1"
                     } bold33`}
                   >
                     ZIL
@@ -194,7 +193,7 @@ const StakingCalculator: React.FC = () => {
                     } 
                         
                     ${
-                      !isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) 
+                      !isWalletConnected
                         ? "placeholder-gray4"
                         : "placeholder-gray8"
                     }
@@ -204,7 +203,7 @@ const StakingCalculator: React.FC = () => {
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     status={!canStake ? "warning" : undefined}
-                    disabled={!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) }
+                    disabled={!isWalletConnected}
                   />
                 </div>
 
@@ -214,7 +213,7 @@ const StakingCalculator: React.FC = () => {
                       {isPoolLiquid() && (
                         <span
                           className={` ${
-                            !isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) && "text-gray4"
+                            !isWalletConnected && "text-gray4"
                           } medium17`}
                         >
                           ~
@@ -236,7 +235,7 @@ const StakingCalculator: React.FC = () => {
                       )}
                       <span
                         className={`
-                         ${!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) ? "text-gray4":
+                         ${!isWalletConnected ? "text-gray4":
                             stakingPoolForView?.stakingPool.definition
                               .poolType === StakingPoolType.LIQUID
                               ? "text-aqua1"
@@ -257,7 +256,7 @@ const StakingCalculator: React.FC = () => {
                   )}
                   <span
                     className={`
-                        ${!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) ? "text-gray4":
+                        ${!isWalletConnected ? "text-gray4":
                           stakingPoolForView?.stakingPool.definition
                             .poolType === StakingPoolType.LIQUID
                             ? "text-aqua1"
@@ -275,7 +274,7 @@ const StakingCalculator: React.FC = () => {
                   onClick={onMaxClick}
                   onMouseEnter={() => setIsMaxHovered(true)}
                   onMouseLeave={() => setIsMaxHovered(false)}
-                  disabled={!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n)}
+                  disabled={!isWalletConnected  || parseEther(minValue) > (zilAvailable || 0n)}
                 >
                   MAX
                 </Button>
@@ -284,7 +283,7 @@ const StakingCalculator: React.FC = () => {
                   onClick={onMinClick}
                   onMouseEnter={() => setIsMinHovered(true)}
                   onMouseLeave={() => setIsMinHovered(false)}
-                  disabled={!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n)}
+                  disabled={!isWalletConnected}
                 >
                   MIN
                 </Button>
@@ -293,7 +292,7 @@ const StakingCalculator: React.FC = () => {
           </Tooltip>
           <div className="flex flex-col">
             <div className="flex mt-2 mb-3">
-              {isWalletConnected || parseEther(minValue) < (zilAvailable || 0n) ? (
+              {isWalletConnected ? (
                 <>
                   {canStake || isStakingInProgress ? (
                     <Button
@@ -361,7 +360,7 @@ const StakingCalculator: React.FC = () => {
               </div>
             )}
 
-            <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2 lg:pb-10">
+            <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 mt-2.5 lg:mt-4 4k:mt-6 border-t border-black2 lg:pb-10">
               <div className="flex flex-col lg:gap-3.5 gap-1 4k:gap-4 regular-base">
                 <div className=" flex ">
                   Commission Fee:{" "}

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -124,6 +124,12 @@ const StakingCalculator: React.FC = () => {
         canStake: false,
         whyCantStake: `Amount ${zilToStakeNumber} ZIL is below minimum stake ${formatUnits(stakingPoolForView.stakingPool.definition.minimumStake, 18)} ZIL`,
       }
+    } else if (!isWalletConnected
+    ) {
+      return {
+        canStake: false,
+        whyCantStake: "Please connect your wallet first.",
+      }
     } else {
       return {
         canStake: true,
@@ -361,7 +367,7 @@ const StakingCalculator: React.FC = () => {
             )}
 
             <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 mt-2.5 lg:mt-4 4k:mt-6 border-t border-black2 lg:pb-10">
-              <div className="flex flex-col lg:gap-3.5 gap-1 4k:gap-4 regular-base">
+              <div className="flex flex-col lg:gap-2.5 gap-1 4k:gap-4 regular-base">
                 <div className=" flex ">
                   Commission Fee:{" "}
                   {stakingPoolForView!.stakingPool.data ? (
@@ -387,7 +393,7 @@ const StakingCalculator: React.FC = () => {
                   </Tooltip>{" "}
                 </div>
               </div>
-              <div className="flex flex-col lg:gray-base gray-base2 xl:gap-3.5 4k:gap-5 xl:items-end justify-start">
+              <div className="flex flex-col lg:gray-base gray-base2 xl:gap-2.5 4k:gap-5 xl:items-end justify-start">
                 {isPoolLiquid() && (
                   <div className="flex  max-lg:gap-2 max-xl:justify-between max-lg:items-start flex-row xl:gap-5 4k:gap-6">
                     <div className=" ">Rate</div>

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -74,8 +74,7 @@ const StakingCalculator: React.FC = () => {
   const [isFocused, setIsFocused] = useState(true)
 
   const handleFocus = () => {
-    if( parseEther(minValue) < (zilAvailable || 0n) )
-    setIsFocused(true)
+    if (parseEther(minValue) < (zilAvailable || 0n)) setIsFocused(true)
   }
 
   const handleBlur = () => {
@@ -99,15 +98,12 @@ const StakingCalculator: React.FC = () => {
         canStake: false,
         whyCantStake: "Loading staking pool data",
       }
-    } 
-    else if (!isWalletConnected
-    ) {
+    } else if (!isWalletConnected) {
       return {
         canStake: false,
         whyCantStake: "Please connect your wallet first.",
       }
-    }
-    else if (zilToStakeNumber <= 0 || isNaN(zilToStakeNumber)) {
+    } else if (zilToStakeNumber <= 0 || isNaN(zilToStakeNumber)) {
       return {
         canStake: false,
         whyCantStake: "Please enter a valid amount",
@@ -132,7 +128,7 @@ const StakingCalculator: React.FC = () => {
         canStake: false,
         whyCantStake: `Amount ${zilToStakeNumber} ZIL is below minimum stake ${formatUnits(stakingPoolForView.stakingPool.definition.minimumStake, 18)} ZIL`,
       }
-    }  else {
+    } else {
       return {
         canStake: true,
         whyCantStake: "",
@@ -169,11 +165,16 @@ const StakingCalculator: React.FC = () => {
             arrow={true}
             overlayClassName="custom-tooltip"
             className=""
-            title= {canStake ? `Earning ${stakingPoolForView!.stakingPool.data ? formatPercentage(stakingPoolForView?.stakingPool.data.apr) : 0}` : whyCantStake}
+            title={
+              canStake
+                ? `Earning ${stakingPoolForView!.stakingPool.data ? formatPercentage(stakingPoolForView?.stakingPool.data.apr) : 0}`
+                : whyCantStake
+            }
           >
             <div
               className={`transition-all duration-300 border-transparent bg-gray-gradient
-              ${  isWalletConnected &&
+              ${
+                isWalletConnected &&
                 ` ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
                   ${isMaxValue && "bg-teal-gradient !border-teal"}
                   ${isMaxHovered && "!bg-teal-gradient"}
@@ -243,12 +244,14 @@ const StakingCalculator: React.FC = () => {
                       )}
                       <span
                         className={`
-                         ${!isWalletConnected ? "text-gray4":
-                            stakingPoolForView?.stakingPool.definition
-                              .poolType === StakingPoolType.LIQUID
-                              ? "text-aqua1"
-                              : "text-purple3"
-                          } medium17 ml-3 mr-1`}
+                         ${
+                           !isWalletConnected
+                             ? "text-gray4"
+                             : stakingPoolForView?.stakingPool.definition
+                                   .poolType === StakingPoolType.LIQUID
+                               ? "text-aqua1"
+                               : "text-purple3"
+                         } medium17 ml-3 mr-1`}
                       >
                         ~
                         {formatPercentage(
@@ -264,11 +267,13 @@ const StakingCalculator: React.FC = () => {
                   )}
                   <span
                     className={`
-                        ${!isWalletConnected ? "text-gray4":
-                          stakingPoolForView?.stakingPool.definition
-                            .poolType === StakingPoolType.LIQUID
-                            ? "text-aqua1"
-                            : "text-purple3"
+                        ${
+                          !isWalletConnected
+                            ? "text-gray4"
+                            : stakingPoolForView?.stakingPool.definition
+                                  .poolType === StakingPoolType.LIQUID
+                              ? "text-aqua1"
+                              : "text-purple3"
                         } medium17`}
                   >
                     APR
@@ -282,7 +287,10 @@ const StakingCalculator: React.FC = () => {
                   onClick={onMaxClick}
                   onMouseEnter={() => setIsMaxHovered(true)}
                   onMouseLeave={() => setIsMaxHovered(false)}
-                  disabled={!isWalletConnected  || parseEther(minValue) > (zilAvailable || 0n)}
+                  disabled={
+                    !isWalletConnected ||
+                    parseEther(minValue) > (zilAvailable || 0n)
+                  }
                 >
                   MAX
                 </Button>

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -171,7 +171,7 @@ ${ isWalletConnected &&
     ${isMaxHovered && "!bg-teal-gradient"}
     ${isMinValue && "!bg-purple-gradient"}
     ${isMinHovered && "!bg-purple-gradient"}
-    ${!canStake &&  "!bg-red-gradient"}`
+    ${!canStake && zilToStake != "0" &&  "!bg-red-gradient"}`
 }
            !bg-transparent flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
             >

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -160,14 +160,14 @@ const StakingCalculator: React.FC = () => {
             title={`Earning ${stakingPoolForView!.stakingPool.data ? formatPercentage(stakingPoolForView?.stakingPool.data.apr) : 0}`}
           >
             <div
-              className={`transition-all duration-300 border-transparent
-${
-  isPoolLiquid()
-    ? "hover:!border-aqua1 hover:shadow-[inset_0_0_7px_3px_rgba(0,208,198,0.3),inset_0_0_15px_8px_rgba(0,208,198,0.15)]"
-    : "hover:!border-purple5 hover:shadow-[inset_0_0_7px_3px_rgba(91,111,255,0.3),inset_0_0_15px_8px_rgba(91,111,255,0.15)]"
+              className={`transition-all duration-300 border-transparent bg-gray-gradient
+${ isWalletConnected &&
+ `  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
+    ${isMaxValue && "!bg-teal-gradient"}
+    ${isMinValue && "!bg-purple-gradient"}
+    ${!canStake &&  "!bg-red-gradient"}`
 }
-          ${isFocused && "ant-input-affix-wrapper-focused !border-transparent"}
-           !bg-transparent flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 bg-grey-gradient rounded-xl items-center`}
+           !bg-transparent flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
             >
               <div className="h-fit self-center">
                 <div className=" flex items-center gap-2">
@@ -175,9 +175,7 @@ ${
                     className={`${
                       zilToStake === "0" || zilToStake === ""
                         ? "text-gray8"
-                        : !canStake && isWalletConnected
-                          ? "text-red1"
-                          : "text-white1"
+                        : "text-white1"
                     } bold33`}
                   >
                     ZIL
@@ -188,15 +186,14 @@ ${
                     className={` ${
                       zilToStake === "0" || zilToStake === ""
                         ? "text-gray8"
-                        : !canStake && isWalletConnected
-                          ? "text-red1"
-                          : "text-white1"
+                        : "text-white1"
                     } placeholder-gray8 flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
                     value={zilToStake !== "0" ? zilToStake || "" : ""}
                     onChange={handleChange}
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     status={!canStake ? "warning" : undefined}
+                    disabled={!isWalletConnected}
                   />
                 </div>
 
@@ -259,12 +256,14 @@ ${
                 <Button
                   className={`btn-secondary-teal ${isMaxValue && "!border-aqua1"}`}
                   onClick={onMaxClick}
+                  disabled={!isWalletConnected}
                 >
                   MAX
                 </Button>
                 <Button
                   className={`btn-secondary-purple ${isMinValue && "!border-purple4"}`}
                   onClick={onMinClick}
+                  disabled={!isWalletConnected}
                 >
                   MIN
                 </Button>

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -148,6 +148,10 @@ const StakingCalculator: React.FC = () => {
     }
   }, [isFocused])
 
+  const [isMinHovered, setIsMinHovered] = useState(false);
+  const [isMaxHovered, setIsMaxHovered] = useState(false);
+
+
   return (
     stakingPoolForView && (
       <>
@@ -164,7 +168,9 @@ const StakingCalculator: React.FC = () => {
 ${ isWalletConnected &&
  `  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
     ${isMaxValue && "!bg-teal-gradient"}
+    ${isMaxHovered && "!bg-teal-gradient"}
     ${isMinValue && "!bg-purple-gradient"}
+    ${isMinHovered && "!bg-purple-gradient"}
     ${!canStake &&  "!bg-red-gradient"}`
 }
            !bg-transparent flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
@@ -256,6 +262,8 @@ ${ isWalletConnected &&
                 <Button
                   className={`btn-secondary-teal ${isMaxValue && "!border-aqua1"}`}
                   onClick={onMaxClick}
+                  onMouseEnter={() => setIsMaxHovered(true)}
+                  onMouseLeave={() => setIsMaxHovered(false)}
                   disabled={!isWalletConnected}
                 >
                   MAX
@@ -263,6 +271,8 @@ ${ isWalletConnected &&
                 <Button
                   className={`btn-secondary-purple ${isMinValue && "!border-purple4"}`}
                   onClick={onMinClick}
+                  onMouseEnter={() => setIsMinHovered(true)}
+                  onMouseLeave={() => setIsMinHovered(false)}
                   disabled={!isWalletConnected}
                 >
                   MIN

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -36,12 +36,7 @@ const StakingCalculator: React.FC = () => {
 
   const { stakingPoolForView } = StakingPoolsStorage.useContainer()
 
-  const [zilToStake, setZilToStake] = useState<string>(
-    formatUnits(
-      stakingPoolForView?.stakingPool.definition.minimumStake || 0n,
-      18
-    )
-  )
+  const [zilToStake, setZilToStake] = useState<string>("0")
 
   const [isMinValue, setIsMinValue] = useState(false)
   const [isMaxValue, setIsMaxValue] = useState(false)
@@ -79,7 +74,6 @@ const StakingCalculator: React.FC = () => {
   const [isFocused, setIsFocused] = useState(true)
 
   const handleFocus = () => {
-    if (zilToStake === "") onMinClick()
     setIsFocused(true)
   }
 
@@ -92,8 +86,6 @@ const StakingCalculator: React.FC = () => {
       valueTemp = zilToStake.slice(0, -1)
     }
     setZilToStake(valueTemp.replace(/0*(\d+)/, "$1"))
-
-    if (zilToStake === "") onMinClick()
     setIsFocused(false)
   }
 
@@ -192,14 +184,15 @@ ${
                   </div>
                   <Input
                     ref={inputRef}
+                    placeholder="0"
                     className={` ${
                       zilToStake === "0" || zilToStake === ""
                         ? "text-gray8"
                         : !canStake && isWalletConnected
                           ? "text-red1"
                           : "text-white1"
-                    } flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
-                    value={zilToStake}
+                    } placeholder-gray8 flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
+                    value={zilToStake !== "0" ? zilToStake || "" : ""}
                     onChange={handleChange}
                     onFocus={handleFocus}
                     onBlur={handleBlur}

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -74,6 +74,7 @@ const StakingCalculator: React.FC = () => {
   const [isFocused, setIsFocused] = useState(true)
 
   const handleFocus = () => {
+    if( parseEther(minValue) < (zilAvailable || 0n) )
     setIsFocused(true)
   }
 
@@ -160,12 +161,12 @@ const StakingCalculator: React.FC = () => {
             arrow={true}
             overlayClassName="custom-tooltip"
             className=""
-            title={`Earning ${stakingPoolForView!.stakingPool.data ? formatPercentage(stakingPoolForView?.stakingPool.data.apr) : 0}`}
+            title= {canStake ? `Earning ${stakingPoolForView!.stakingPool.data ? formatPercentage(stakingPoolForView?.stakingPool.data.apr) : 0}` : whyCantStake}
           >
             <div
               className={`transition-all duration-300 border-transparent bg-gray-gradient
               ${
-                isWalletConnected || parseEther(minValue) < (zilAvailable || 0n)  &&
+              (  isWalletConnected || parseEther(minValue) < (zilAvailable || 0n) ) &&
                 `  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
                   ${isMaxValue && "bg-teal-gradient !border-teal"}
                   ${isMaxHovered && "!bg-teal-gradient"}

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -171,7 +171,7 @@ ${ isWalletConnected &&
     ${isMaxHovered && "!bg-teal-gradient"}
     ${isMinValue && "!bg-purple-gradient"}
     ${isMinHovered && "!bg-purple-gradient"}
-    ${!canStake && zilToStake != "0" &&  "!bg-red-gradient"}`
+    ${!canStake && zilToStake != "0" && zilToStake != "" &&  "!bg-red-gradient"}`
 }
            !bg-transparent flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
             >
@@ -179,8 +179,8 @@ ${ isWalletConnected &&
                 <div className=" flex items-center gap-2">
                   <div
                     className={`${
-                      zilToStake === "0" || zilToStake === ""
-                        ? "text-gray8"
+                      !isWalletConnected
+                        ? "text-gray4"
                         : "text-white1"
                     } bold33`}
                   >
@@ -190,10 +190,18 @@ ${ isWalletConnected &&
                     ref={inputRef}
                     placeholder="0"
                     className={` ${
+                      
                       zilToStake === "0" || zilToStake === ""
                         ? "text-gray8"
                         : "text-white1"
-                    } placeholder-gray8 flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
+                    } 
+                        
+                    ${
+                      !isWalletConnected
+                        ? "placeholder-gray4"
+                        : "placeholder-gray8"
+                    }
+                         flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
                     value={zilToStake !== "0" ? zilToStake || "" : ""}
                     onChange={handleChange}
                     onFocus={handleFocus}
@@ -207,7 +215,11 @@ ${ isWalletConnected &&
                   {stakingPoolForView!.stakingPool.data ? (
                     <>
                       {isPoolLiquid() && (
-                        <span className="medium17">
+                        <span className=
+                        {` ${
+                      !isWalletConnected
+                        && "text-gray4" 
+                    } medium17`}>
                           ~
                           {!isNaN(zilToStakeNumber) &&
                           !isNaN(
@@ -226,7 +238,12 @@ ${ isWalletConnected &&
                         </span>
                       )}
                       <span
-                        className={`${
+                        className={`
+                         ${
+                            !isWalletConnected
+                              && "text-gray4" 
+                          }
+                          ${
                           stakingPoolForView?.stakingPool.definition
                             .poolType === StakingPoolType.LIQUID
                             ? "text-aqua1"
@@ -246,7 +263,12 @@ ${ isWalletConnected &&
                     </div>
                   )}
                   <span
-                    className={`${
+                    className={`
+                        ${
+                          !isWalletConnected
+                            && "text-gray4" 
+                          }
+                        ${
                       stakingPoolForView?.stakingPool.definition.poolType ===
                       StakingPoolType.LIQUID
                         ? "text-aqua1"

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -148,9 +148,8 @@ const StakingCalculator: React.FC = () => {
     }
   }, [isFocused])
 
-  const [isMinHovered, setIsMinHovered] = useState(false);
-  const [isMaxHovered, setIsMaxHovered] = useState(false);
-
+  const [isMinHovered, setIsMinHovered] = useState(false)
+  const [isMaxHovered, setIsMaxHovered] = useState(false)
 
   return (
     stakingPoolForView && (
@@ -165,23 +164,21 @@ const StakingCalculator: React.FC = () => {
           >
             <div
               className={`transition-all duration-300 border-transparent bg-gray-gradient
-${ isWalletConnected &&
- `  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
-    ${isMaxValue && "!bg-teal-gradient"}
-    ${isMaxHovered && "!bg-teal-gradient"}
-    ${isMinValue && "!bg-purple-gradient"}
-    ${isMinHovered && "!bg-purple-gradient"}
-    ${!canStake && zilToStake != "0" && zilToStake != "" &&  "!bg-red-gradient"}`
-}
-           !bg-transparent flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
+              ${
+                isWalletConnected &&
+                `  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
+                  ${isMaxValue && "!bg-teal-gradient !border-teal"}
+                  ${isMaxHovered && "!bg-teal-gradient"}
+                  ${isMinValue && "!bg-purple-gradient"}
+                  ${isMinHovered && "!bg-purple-gradient"}
+                  ${!canStake && zilToStake != "0" && zilToStake != "" && "!bg-red-gradient"}`
+              } flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
             >
               <div className="h-fit self-center">
                 <div className=" flex items-center gap-2">
                   <div
                     className={`${
-                      !isWalletConnected
-                        ? "text-gray4"
-                        : "text-white1"
+                      !isWalletConnected ? "text-gray4" : "text-white1"
                     } bold33`}
                   >
                     ZIL
@@ -190,7 +187,6 @@ ${ isWalletConnected &&
                     ref={inputRef}
                     placeholder="0"
                     className={` ${
-                      
                       zilToStake === "0" || zilToStake === ""
                         ? "text-gray8"
                         : "text-white1"
@@ -215,11 +211,11 @@ ${ isWalletConnected &&
                   {stakingPoolForView!.stakingPool.data ? (
                     <>
                       {isPoolLiquid() && (
-                        <span className=
-                        {` ${
-                      !isWalletConnected
-                        && "text-gray4" 
-                    } medium17`}>
+                        <span
+                          className={` ${
+                            !isWalletConnected && "text-gray4"
+                          } medium17`}
+                        >
                           ~
                           {!isNaN(zilToStakeNumber) &&
                           !isNaN(
@@ -239,16 +235,13 @@ ${ isWalletConnected &&
                       )}
                       <span
                         className={`
-                         ${
-                            !isWalletConnected
-                              && "text-gray4" 
-                          }
+                         ${!isWalletConnected && "text-gray4"}
                           ${
-                          stakingPoolForView?.stakingPool.definition
-                            .poolType === StakingPoolType.LIQUID
-                            ? "text-aqua1"
-                            : "text-purple3"
-                        } medium17 ml-3 mr-1`}
+                            stakingPoolForView?.stakingPool.definition
+                              .poolType === StakingPoolType.LIQUID
+                              ? "text-aqua1"
+                              : "text-purple3"
+                          } medium17 ml-3 mr-1`}
                       >
                         ~
                         {formatPercentage(
@@ -264,16 +257,13 @@ ${ isWalletConnected &&
                   )}
                   <span
                     className={`
+                        ${!isWalletConnected && "text-gray4"}
                         ${
-                          !isWalletConnected
-                            && "text-gray4" 
-                          }
-                        ${
-                      stakingPoolForView?.stakingPool.definition.poolType ===
-                      StakingPoolType.LIQUID
-                        ? "text-aqua1"
-                        : "text-purple3"
-                    } medium17`}
+                          stakingPoolForView?.stakingPool.definition
+                            .poolType === StakingPoolType.LIQUID
+                            ? "text-aqua1"
+                            : "text-purple3"
+                        } medium17`}
                   >
                     APR
                   </span>

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -99,7 +99,15 @@ const StakingCalculator: React.FC = () => {
         canStake: false,
         whyCantStake: "Loading staking pool data",
       }
-    } else if (zilToStakeNumber <= 0 || isNaN(zilToStakeNumber)) {
+    } 
+    else if (!isWalletConnected
+    ) {
+      return {
+        canStake: false,
+        whyCantStake: "Please connect your wallet first.",
+      }
+    }
+    else if (zilToStakeNumber <= 0 || isNaN(zilToStakeNumber)) {
       return {
         canStake: false,
         whyCantStake: "Please enter a valid amount",
@@ -124,13 +132,7 @@ const StakingCalculator: React.FC = () => {
         canStake: false,
         whyCantStake: `Amount ${zilToStakeNumber} ZIL is below minimum stake ${formatUnits(stakingPoolForView.stakingPool.definition.minimumStake, 18)} ZIL`,
       }
-    } else if (!isWalletConnected
-    ) {
-      return {
-        canStake: false,
-        whyCantStake: "Please connect your wallet first.",
-      }
-    } else {
+    }  else {
       return {
         canStake: true,
         whyCantStake: "",

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -165,11 +165,11 @@ const StakingCalculator: React.FC = () => {
             <div
               className={`transition-all duration-300 border-transparent bg-gray-gradient
               ${
-                isWalletConnected &&
+                isWalletConnected || parseEther(minValue) < (zilAvailable || 0n)  &&
                 `  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
-                  ${isMaxValue && "!bg-teal-gradient !border-teal"}
+                  ${isMaxValue && "bg-teal-gradient !border-teal"}
                   ${isMaxHovered && "!bg-teal-gradient"}
-                  ${isMinValue && "!bg-purple-gradient"}
+                  ${isMinValue && "bg-purple-gradient"}
                   ${isMinHovered && "!bg-purple-gradient"}
                   ${!canStake && zilToStake != "0" && zilToStake != "" && "!bg-red-gradient"}`
               } flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
@@ -178,7 +178,7 @@ const StakingCalculator: React.FC = () => {
                 <div className=" flex items-center gap-2">
                   <div
                     className={`${
-                      !isWalletConnected ? "text-gray4" : "text-white1"
+                      !isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) ? "text-gray4" : "text-white1"
                     } bold33`}
                   >
                     ZIL
@@ -193,7 +193,7 @@ const StakingCalculator: React.FC = () => {
                     } 
                         
                     ${
-                      !isWalletConnected
+                      !isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) 
                         ? "placeholder-gray4"
                         : "placeholder-gray8"
                     }
@@ -203,7 +203,7 @@ const StakingCalculator: React.FC = () => {
                     onFocus={handleFocus}
                     onBlur={handleBlur}
                     status={!canStake ? "warning" : undefined}
-                    disabled={!isWalletConnected}
+                    disabled={!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) }
                   />
                 </div>
 
@@ -213,7 +213,7 @@ const StakingCalculator: React.FC = () => {
                       {isPoolLiquid() && (
                         <span
                           className={` ${
-                            !isWalletConnected && "text-gray4"
+                            !isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) && "text-gray4"
                           } medium17`}
                         >
                           ~
@@ -235,8 +235,7 @@ const StakingCalculator: React.FC = () => {
                       )}
                       <span
                         className={`
-                         ${!isWalletConnected && "text-gray4"}
-                          ${
+                         ${!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) ? "text-gray4":
                             stakingPoolForView?.stakingPool.definition
                               .poolType === StakingPoolType.LIQUID
                               ? "text-aqua1"
@@ -257,8 +256,7 @@ const StakingCalculator: React.FC = () => {
                   )}
                   <span
                     className={`
-                        ${!isWalletConnected && "text-gray4"}
-                        ${
+                        ${!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n) ? "text-gray4":
                           stakingPoolForView?.stakingPool.definition
                             .poolType === StakingPoolType.LIQUID
                             ? "text-aqua1"
@@ -276,7 +274,7 @@ const StakingCalculator: React.FC = () => {
                   onClick={onMaxClick}
                   onMouseEnter={() => setIsMaxHovered(true)}
                   onMouseLeave={() => setIsMaxHovered(false)}
-                  disabled={!isWalletConnected}
+                  disabled={!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n)}
                 >
                   MAX
                 </Button>
@@ -285,7 +283,7 @@ const StakingCalculator: React.FC = () => {
                   onClick={onMinClick}
                   onMouseEnter={() => setIsMinHovered(true)}
                   onMouseLeave={() => setIsMinHovered(false)}
-                  disabled={!isWalletConnected}
+                  disabled={!isWalletConnected || parseEther(minValue) > (zilAvailable || 0n)}
                 >
                   MIN
                 </Button>
@@ -294,7 +292,7 @@ const StakingCalculator: React.FC = () => {
           </Tooltip>
           <div className="flex flex-col">
             <div className="flex mt-2 mb-3">
-              {isWalletConnected ? (
+              {isWalletConnected || parseEther(minValue) < (zilAvailable || 0n) ? (
                 <>
                   {canStake || isStakingInProgress ? (
                     <Button

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -167,14 +167,13 @@ ${
               <div className=" flex items-center gap-2">
                 <div
                   className={`${
-                      !isWalletConnected
-                        ? "text-gray4" 
-                   :
-                    tokensToUnstake === "0" || tokensToUnstake === ""
-                      ? "text-gray8"
-                      : !canUnstake && isWalletConnected
-                        ? "text-red1"
-                        : "text-white1"
+                    !isWalletConnected
+                      ? "text-gray4"
+                      : tokensToUnstake === "0" || tokensToUnstake === ""
+                        ? "text-gray8"
+                        : !canUnstake && isWalletConnected
+                          ? "text-red1"
+                          : "text-white1"
                   } bold33`}
                 >
                   {" "}
@@ -190,9 +189,10 @@ ${
                         ? "text-red1"
                         : "text-white1"
                   }   ${
-                            !isWalletConnected
-                              ? "placeholder-gray4":"placeholder-gray8 "
-                          }
+                    !isWalletConnected
+                      ? "placeholder-gray4"
+                      : "placeholder-gray8 "
+                  }
 flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
                   value={tokensToUnstake !== "0" ? tokensToUnstake || "" : ""}
                   placeholder="0"
@@ -205,10 +205,11 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
               </div>
               <div className="flex items-center ">
                 {isPoolLiquid() && (
-                  <span className= {` ${
-                    !isWalletConnected
-                      && "text-gray4" 
-                  } medium17`}>
+                  <span
+                    className={` ${
+                      !isWalletConnected && "text-gray4"
+                    } medium17`}
+                  >
                     {stakingPoolForView!.stakingPool.data ? (
                       <>
                         {" "}
@@ -230,14 +231,13 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
 
                 <span
                   className={`${
-                      !isWalletConnected
-                        ?"text-gray4" 
-                    :
-                    !isUnstakingAvailable
-                      ? "!text-gray-500"
-                      : isPoolLiquid()
-                        ? "text-aqua1"
-                        : "text-purple3"
+                    !isWalletConnected
+                      ? "text-gray4"
+                      : !isUnstakingAvailable
+                        ? "!text-gray-500"
+                        : isPoolLiquid()
+                          ? "text-aqua1"
+                          : "text-purple3"
                   } medium17 ml-3 `}
                 >
                   {unboudingPeriod}

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -325,7 +325,7 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
             </div>
           )}
 
-          <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 border-t border-black2 lg:pb-10">
+          <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 mt-2.5 lg:mt-4 4k:mt-6 border-t border-black2 lg:pb-10">
             <div className="flex flex-col lg:gap-3.5 gap-1 regular-base">
               <div className=" ">
                 Commission Fee:{" "}

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -167,6 +167,9 @@ ${
               <div className=" flex items-center gap-2">
                 <div
                   className={`${
+                      !isWalletConnected
+                        ? "text-gray4" 
+                   :
                     tokensToUnstake === "0" || tokensToUnstake === ""
                       ? "text-gray8"
                       : !canUnstake && isWalletConnected
@@ -186,7 +189,11 @@ ${
                       : !canUnstake && isWalletConnected
                         ? "text-red1"
                         : "text-white1"
-                  } placeholder-gray8 flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
+                  }   ${
+                            !isWalletConnected
+                              ? "placeholder-gray4":"placeholder-gray8 "
+                          }
+flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
                   value={tokensToUnstake !== "0" ? tokensToUnstake || "" : ""}
                   placeholder="0"
                   onChange={handleChange}
@@ -198,7 +205,10 @@ ${
               </div>
               <div className="flex items-center ">
                 {isPoolLiquid() && (
-                  <span className="medium17">
+                  <span className= {` ${
+                    !isWalletConnected
+                      && "text-gray4" 
+                  } medium17`}>
                     {stakingPoolForView!.stakingPool.data ? (
                       <>
                         {" "}
@@ -220,6 +230,9 @@ ${
 
                 <span
                   className={`${
+                      !isWalletConnected
+                        ?"text-gray4" 
+                    :
                     !isUnstakingAvailable
                       ? "!text-gray-500"
                       : isPoolLiquid()

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -137,6 +137,9 @@ const UnstakingCalculator: React.FC = () => {
     }
   })()
 
+  const [isMinHovered, setIsMinHovered] = useState(false)
+  const [isMaxHovered, setIsMaxHovered] = useState(false)
+  
   return (
     stakingPoolForView && (
       <FastFadeScroll
@@ -151,29 +154,26 @@ const UnstakingCalculator: React.FC = () => {
           title="Enter amount to request unstake."
         >
           <div
-            className={`transition-all duration-300 border-transparent
+            className={`transition-all duration-300 border-transparent bg-gray-gradient
 ${
   isUnstakingAvailable &&
-  ` ${
-    isPoolLiquid()
-      ? "hover:border-aqua1 hover:shadow-[inset_0_0_7px_3px_rgba(0,208,198,0.3),inset_0_0_15px_8px_rgba(0,208,198,0.15)]"
-      : "hover:border-purple5 hover:shadow-[inset_0_0_7px_3px_rgba(91,111,255,0.3),inset_0_0_15px_8px_rgba(91,111,255,0.15)]"
-  }
-          ${isFocused && "ant-input-affix-wrapper-focused !border-transparent"} `
-}
-           !bg-transparent flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 bg-grey-gradient rounded-xl items-center`}
+  ` 
+
+  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
+                  ${isMaxValue && "!bg-teal-gradient !border-teal"}
+                  ${isMaxHovered && "!bg-teal-gradient"}
+                  ${isMinValue && "!bg-purple-gradient"}
+                  ${isMinHovered && "!bg-purple-gradient"}
+                  ${!canUnstake && tokensToUnstake != "0" && tokensToUnstake != "" && "!bg-red-gradient"}`
+              } flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
           >
             <div className="h-fit self-center">
               <div className=" flex items-center gap-2">
                 <div
                   className={`${
                     !isWalletConnected
-                      ? "text-gray4"
-                      : tokensToUnstake === "0" || tokensToUnstake === ""
-                        ? "text-gray8"
-                        : !canUnstake && isWalletConnected
-                          ? "text-red1"
-                          : "text-white1"
+                      ? "text-gray4" 
+                      : "text-white1"
                   } bold33`}
                 >
                   {" "}
@@ -185,8 +185,6 @@ ${
                   className={`${
                     tokensToUnstake === "0" || tokensToUnstake === ""
                       ? "text-gray8"
-                      : !canUnstake && isWalletConnected
-                        ? "text-red1"
                         : "text-white1"
                   }   ${
                     !isWalletConnected
@@ -248,6 +246,8 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
               <Button
                 className={`btn-secondary-teal ${isMaxValue && "!border-aqua1"}`}
                 onClick={onMaxClick}
+                onMouseEnter={() => setIsMaxHovered(true)}
+                onMouseLeave={() => setIsMaxHovered(false)}
                 disabled={!isUnstakingAvailable}
               >
                 MAX
@@ -259,6 +259,8 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
                   setIsMinValue(true)
                   setIsMaxValue(false)
                 }}
+                onMouseEnter={() => setIsMinHovered(true)}
+                onMouseLeave={() => setIsMinHovered(false)}
                 disabled={!isUnstakingAvailable}
               >
                 MIN

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -171,7 +171,7 @@ ${
               <div className=" flex items-center gap-2">
                 <div
                   className={`${
-                    !isWalletConnected
+                    !isWalletConnected || !isUnstakingAvailable
                       ? "text-gray4" 
                       : "text-white1"
                   } bold33`}
@@ -187,7 +187,7 @@ ${
                       ? "text-gray8"
                         : "text-white1"
                   }   ${
-                    !isWalletConnected
+                    !isWalletConnected || !isUnstakingAvailable
                       ? "placeholder-gray4"
                       : "placeholder-gray8 "
                   }
@@ -205,7 +205,7 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
                 {isPoolLiquid() && (
                   <span
                     className={` ${
-                      !isWalletConnected && "text-gray4"
+                      !isWalletConnected || !isUnstakingAvailable && "text-gray4"
                     } medium17`}
                   >
                     {stakingPoolForView!.stakingPool.data ? (
@@ -229,7 +229,7 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
 
                 <span
                   className={`${
-                    !isWalletConnected
+                    !isWalletConnected || !isUnstakingAvailable
                       ? "text-gray4"
                       : !isUnstakingAvailable
                         ? "!text-gray-500"

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -151,21 +151,27 @@ const UnstakingCalculator: React.FC = () => {
           arrow={true}
           overlayClassName="custom-tooltip"
           className=""
-          title="Enter amount to unstake."
+          title={
+            !isWalletConnected
+              ? "Please connect your wallet first."
+              : isUnstakingAvailable
+                ? "Enter amount to unstake."
+                : "You'll need to stake first."
+          }
         >
           <div
-            className={`transition-all duration-300 border-transparent bg-gray-gradient
-${
-  isUnstakingAvailable &&
-  ` 
-
-  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
+            className={`transition-all duration-300 border-transparent bg-gray-gradient 
+              ${
+                isUnstakingAvailable &&
+                ` 
+                  ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
                   ${isMaxValue && "bg-teal-gradient !border-teal"}
                   ${isMaxHovered && "!bg-teal-gradient"}
                   ${isMinValue && "bg-purple-gradient"}
                   ${isMinHovered && "!bg-purple-gradient"}
                   ${!canUnstake && tokensToUnstake != "0" && tokensToUnstake != "" && "!bg-red-gradient"}`
-} flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
+              }
+              flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
           >
             <div className="h-fit self-center">
               <div className=" flex items-center gap-2">

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -160,9 +160,9 @@ ${
   ` 
 
   ${isFocused && "ant-input-affix-wrapper-focused !border-transparent !bg-focus-gradient "}
-                  ${isMaxValue && "!bg-teal-gradient !border-teal"}
+                  ${isMaxValue && "bg-teal-gradient !border-teal"}
                   ${isMaxHovered && "!bg-teal-gradient"}
-                  ${isMinValue && "!bg-purple-gradient"}
+                  ${isMinValue && "bg-purple-gradient"}
                   ${isMinHovered && "!bg-purple-gradient"}
                   ${!canUnstake && tokensToUnstake != "0" && tokensToUnstake != "" && "!bg-red-gradient"}`
               } flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -139,7 +139,7 @@ const UnstakingCalculator: React.FC = () => {
 
   const [isMinHovered, setIsMinHovered] = useState(false)
   const [isMaxHovered, setIsMaxHovered] = useState(false)
-  
+
   return (
     stakingPoolForView && (
       <FastFadeScroll
@@ -165,14 +165,14 @@ ${
                   ${isMinValue && "bg-purple-gradient"}
                   ${isMinHovered && "!bg-purple-gradient"}
                   ${!canUnstake && tokensToUnstake != "0" && tokensToUnstake != "" && "!bg-red-gradient"}`
-              } flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
+} flex justify-between lg:gap-10 4k:gap-14 mb-2.5 lg:mb-4 4k:mb-6 p-3 lg:p-5 xl:p-7 4k:p-10 rounded-xl items-center`}
           >
             <div className="h-fit self-center">
               <div className=" flex items-center gap-2">
                 <div
                   className={`${
                     !isWalletConnected || !isUnstakingAvailable
-                      ? "text-gray4" 
+                      ? "text-gray4"
                       : "text-white1"
                   } bold33`}
                 >
@@ -185,7 +185,7 @@ ${
                   className={`${
                     tokensToUnstake === "0" || tokensToUnstake === ""
                       ? "text-gray8"
-                        : "text-white1"
+                      : "text-white1"
                   }   ${
                     !isWalletConnected || !isUnstakingAvailable
                       ? "placeholder-gray4"
@@ -205,7 +205,8 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
                 {isPoolLiquid() && (
                   <span
                     className={` ${
-                      !isWalletConnected || !isUnstakingAvailable && "text-gray4"
+                      !isWalletConnected ||
+                      (!isUnstakingAvailable && "text-gray4")
                     } medium17`}
                   >
                     {stakingPoolForView!.stakingPool.data ? (

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -326,7 +326,7 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
           )}
 
           <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 mt-2.5 lg:mt-4 4k:mt-6 border-t border-black2 lg:pb-10">
-            <div className="flex flex-col lg:gap-3.5 gap-1 regular-base">
+            <div className="flex flex-col lg:gap-2.5 gap-1 regular-base">
               <div className=" ">
                 Commission Fee:{" "}
                 {stakingPoolForView!.stakingPool.data ? (
@@ -357,7 +357,7 @@ flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0
                 </Tooltip>
               </div>
             </div>
-            <div className="flex flex-col lg:gray-base gray-base2 xl:gap-3.5 4k:gap-5 xl:items-end justify-start">
+            <div className="flex flex-col lg:gray-base gray-base2 xl:gap-2.5 4k:gap-5 xl:items-end justify-start">
               {isPoolLiquid() && (
                 <div className="flex flex-col max-xl:justify-between  max-lg:items-start xl:gap-3.5 xl:items-end">
                   <div className="flex   xl:gap-5 4k:gap-6">

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -62,12 +62,12 @@ const UnstakingCalculator: React.FC = () => {
       setIsMinValue(inputValue === "1")
       setIsMaxValue(inputValue === maxValue)
 
+      console.log(isMinValue, "min and ", isMaxValue, "max")
       setZilToUnstake(inputValue)
     }
   }
 
   const handleFocus = () => {
-    if (tokensToUnstake === "") onMaxClick()
     setIsFocused(true)
   }
 
@@ -80,16 +80,8 @@ const UnstakingCalculator: React.FC = () => {
       valueTemp = tokensToUnstake.slice(0, -1)
     }
     setZilToUnstake(valueTemp.replace(/0*(\d+)/, "$1"))
-    if (tokensToUnstake === "") onMaxClick()
-
     setIsFocused(false)
   }
-
-  useEffect(() => {
-    if (stakingPoolForView?.userData) {
-      onMaxClick()
-    }
-  }, [stakingPoolForView?.userData])
 
   const tokenToUnstakeInBaseUnit = parseUnits(
     tokensToUnstake,
@@ -194,8 +186,9 @@ ${
                       : !canUnstake && isWalletConnected
                         ? "text-red1"
                         : "text-white1"
-                  }  flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
-                  value={tokensToUnstake}
+                  } placeholder-gray8 flex items-baseline !bg-transparent !border-transparent !shadow-none bold33 px-0`}
+                  value={tokensToUnstake !== "0" ? tokensToUnstake || "" : ""}
+                  placeholder="0"
                   onChange={handleChange}
                   onBlur={handleBlur}
                   onFocus={handleFocus}
@@ -248,7 +241,11 @@ ${
               </Button>
               <Button
                 className={`btn-secondary-purple ${isMinValue && "!border-purple4"}`}
-                onClick={() => setZilToUnstake("1")}
+                onClick={() => {
+                  setZilToUnstake("1")
+                  setIsMinValue(true)
+                  setIsMaxValue(false)
+                }}
                 disabled={!isUnstakingAvailable}
               >
                 MIN

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -109,7 +109,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
             ) : (
               <div className="loading-blur"> 00000 zil</div>
             )}
-            <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[218px] w-full">
+            <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 lg:max-w-[250px] w-full">
               {getMinimalPoolStakingAmount(reward.address) >
               reward.zilRewardAmount ? (
                 <Tooltip
@@ -217,7 +217,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
               ) : (
                 <div className="loading-blur">000.000 ZIL</div>
               )}
-              <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 max-w-[218px] w-full">
+              <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 max-w-[250px] w-full">
                 <Button
                   className={` 
                     ${

--- a/src/components/withdrawZilView.tsx
+++ b/src/components/withdrawZilView.tsx
@@ -99,7 +99,7 @@ const UnstakeCard: React.FC<UnstakeCardProps> = ({
             )}
         </div>
       </div>
-      <div className="max-lg:gap-2.5 max-lg:flex max-lg:justify-center lg:w-1/3 lg:max-w-[218px] w-full pr-3 lg:pb-0 pb-6 lg:pr-9.5 4k:pr-12">
+      <div className="max-lg:gap-2.5 max-lg:flex max-lg:justify-center lg:w-1/3 lg:max-w-[250px] w-full pr-3 lg:pb-0 pb-6 lg:pr-9.5 4k:pr-12">
         <div className="max-lg:w-1/2">
           <Button
             className={` 
@@ -211,7 +211,7 @@ const RewardCard: React.FC<RewardCardProps> = ({
             )}
         </div>
       </div>
-      <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 w-full lg:max-w-[218px] lg:pb-0 pb-6 lg:pr-9.5 4k:pr-12">
+      <div className="max-lg:gap-2.5 max-lg:flex lg:w-1/3 w-full lg:max-w-[250px] lg:pb-0 pb-6 lg:pr-9.5 4k:pr-12">
         <div className="max-lg:w-1/2">
           {stakingPool.definition.minimumStake > rewardInfo.zilRewardAmount ? (
             <Tooltip

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -74,7 +74,7 @@ const HomePage = () => {
       {!isWalletConnected && !stakingPoolForView ? (
         <LoginView />
       ) : stakingPoolForView ? (
-        <div className="bg-black4/[68%] 4k:rounded-2.5xl rounded-t-2.5xl xs:px-5 lg:px-7.5 4k:px-10 h-full">
+        <div className="bg-black4/[68%] 4k:rounded-2.5xl rounded-tl-2.5xl xs:px-5 lg:px-7.5 4k:px-10 h-full">
           <StakingPoolDetailsView
             stakingPoolData={stakingPoolForView.stakingPool}
             userStakingPoolData={stakingPoolForView.userData.staked}
@@ -376,7 +376,7 @@ const HomePage = () => {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 4k:gap-14 h-full max-lg:pb-16">
             {/* Left column */}
             <div
-              className={`lg:bg-white/[9%] p-4 xs:p-6 4k:p-10 max-4k:rounded-s-none rounded-t-2.5xl ${mobileOverlayContent && "max-lg:hidden"} overflow-hidden h-full flex flex-col `}
+              className={`lg:bg-white/[9%] p-4 xs:p-6 4k:p-10 max-4k:rounded-s-none rounded-tr-2.5xl ${mobileOverlayContent && "max-lg:hidden"} overflow-hidden h-full flex flex-col `}
             >
               <StakingPoolsList
                 selectedPoolType={selectedPoolType}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -139,7 +139,8 @@ button,
     }
 
     &:disabled {
-      @apply !bg-gradientbg !text-gray1 cursor-not-allowed;
+      @apply !text-gray4 border-gray4;
+      background-image: none !important;
     }
   }
 
@@ -148,6 +149,11 @@ button,
 
     &:hover:not(:disabled) {
       @apply !bg-PurpleDarker !shadow-[0px_0px_12.0px_0px_#87A1FF] !text-purple3;
+    }
+
+    &:disabled {
+      @apply !text-gray4 !bg-[#0000000A] border-gray4;
+      background-image: none !important;
     }
   }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -144,7 +144,7 @@ button,
   }
 
   .btn-secondary-purple {
-    @apply btn-secondary-teal !text-white5 !bg-PurpleDarker border-purple4;
+    @apply btn-secondary-teal !text-white5 !bg-PurpleDarker border-transparent;
 
     &:hover:not(:disabled) {
       @apply !bg-PurpleDarker !shadow-[0px_0px_12.0px_0px_#87A1FF] !text-purple3;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -31,6 +31,13 @@ const config: Config = {
 
         "custom-grey-gradient":
           "linear-gradient(90deg, rgba(78, 78, 78, 0.30) 0%, rgba(32, 40, 50, 0.25) 49%, rgba(78, 78, 78, 0.30) 92%)",
+
+          "gray-gradient": "linear-gradient(90deg, rgba(78, 78, 78, 0.30) 0%, rgba(32, 40, 50, 0.25) 50%, rgba(78, 78, 78, 0.30) 92%)",
+          "focus-gradient": "linear-gradient(90deg, rgba(57, 35, 162, 0.20) 0%, rgba(19, 136, 130, 0.20) 100%)",
+          "teal-gradient": "linear-gradient(90deg, rgba(23, 60, 63, 0.40) -2.48%, rgba(23, 60, 63, 0.25) 99.35%)",
+          "purple-gradient": "linear-gradient(90deg, rgba(83, 57, 211, 0.30) -17.49%, rgba(83, 57, 211, 0.15) 90.6%)",
+          "red-gradient": "linear-gradient(90deg, rgba(255, 74, 74, 0.30) -12.7%, rgba(255, 74, 74, 0.20) 66.28%)",
+
       },
       colors: {
         black1: "#010101",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,12 +32,16 @@ const config: Config = {
         "custom-grey-gradient":
           "linear-gradient(90deg, rgba(78, 78, 78, 0.30) 0%, rgba(32, 40, 50, 0.25) 49%, rgba(78, 78, 78, 0.30) 92%)",
 
-          "gray-gradient": "linear-gradient(90deg, rgba(78, 78, 78, 0.30) 0%, rgba(32, 40, 50, 0.25) 50%, rgba(78, 78, 78, 0.30) 92%)",
-          "focus-gradient": "linear-gradient(90deg, rgba(57, 35, 162, 0.20) 0%, rgba(19, 136, 130, 0.20) 100%)",
-          "teal-gradient": "linear-gradient(90deg, rgba(23, 60, 63, 0.40) -2.48%, rgba(23, 60, 63, 0.25) 99.35%)",
-          "purple-gradient": "linear-gradient(90deg, rgba(83, 57, 211, 0.30) -17.49%, rgba(83, 57, 211, 0.15) 90.6%)",
-          "red-gradient": "linear-gradient(90deg, rgba(255, 74, 74, 0.30) -12.7%, rgba(255, 74, 74, 0.20) 66.28%)",
-
+        "gray-gradient":
+          "linear-gradient(90deg, rgba(78, 78, 78, 0.30) 0%, rgba(32, 40, 50, 0.25) 50%, rgba(78, 78, 78, 0.30) 92%)",
+        "focus-gradient":
+          "linear-gradient(90deg, rgba(57, 35, 162, 0.20) 0%, rgba(19, 136, 130, 0.20) 100%)",
+        "teal-gradient":
+          "linear-gradient(90deg, rgba(23, 60, 63, 0.40) -2.48%, rgba(23, 60, 63, 0.25) 99.35%)",
+        "purple-gradient":
+          "linear-gradient(90deg, rgba(83, 57, 211, 0.30) -17.49%, rgba(83, 57, 211, 0.15) 90.6%)",
+        "red-gradient":
+          "linear-gradient(90deg, rgba(255, 74, 74, 0.30) -12.7%, rgba(255, 74, 74, 0.20) 66.28%)",
       },
       colors: {
         black1: "#010101",


### PR DESCRIPTION
#description: 
APT-1857 - APT-1852:
set initial values to null and add 0 placeholder in inputs
for disabled cases let the input info be all grayed beside the btns min max
when wallet not connected disable input in stake
disable max btn if the user's zil are less than the min value
add hover and clicked effects to the input container for focus, min, max and error values:
when hover min max override the clicked style
set the focused to be true when opening each tab so the user can see input easily
change tooltip of the input field to match the btn in case of errors
replace red text with normal when error value
keep value label white when input enabled regardless the value

APT-1859: 
make btns wider when needed

minor fixes: 
fix top right rounded corner of right view
fix spacing in lower info in calculators 
change input tooltip to ask for connecting wallet when not connected