### PR TITLE
APT-1870: Staking exchange rate info inversed

### DIFF
--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -2,13 +2,12 @@ import { StakingPoolsStorage } from "@/contexts/stakingPoolsStorage"
 import { useEffect, useRef, useState } from "react"
 import { Button, Input, InputRef, Tooltip } from "antd"
 import { WalletConnector } from "@/contexts/walletConnector"
-
 import {
   formatPercentage,
   convertZilValueInToken,
-  getTxExplorerUrl,
-  formatAddress,
   getHumanFormDuration,
+  formatUnitsToHumanReadable,
+  convertTokenToZil,
 } from "@/misc/formatting"
 import { formatUnits, parseEther } from "viem"
 import { StakingOperations } from "@/contexts/stakingOperations"
@@ -395,7 +394,24 @@ const StakingCalculator: React.FC = () => {
                   <div className="flex  max-lg:gap-2 max-xl:justify-between max-lg:items-start flex-row xl:gap-5 4k:gap-6">
                     <div className=" ">Rate</div>
                     {stakingPoolForView!.stakingPool.data ? (
-                      <div className="text-gray9">{`1 ZIL = ~${stakingPoolForView.stakingPool.data.zilToTokenRate.toPrecision(3)} ${stakingPoolForView.stakingPool.definition.tokenSymbol}`}</div>
+                      <div className="text-gray9">
+                        <>
+                          1{" "}
+                          {
+                            stakingPoolForView.stakingPool.definition
+                              .tokenSymbol
+                          }{" "}
+                          =~
+                          {formatUnitsToHumanReadable(
+                            convertTokenToZil(
+                              parseEther("1"),
+                              stakingPoolForView.stakingPool.data.zilToTokenRate
+                            ),
+                            18
+                          )}
+                        </>{" "}
+                        ZIL
+                      </div>
                     ) : (
                       <div className="loading-blur ml-1 "> 1 ZIL = ~00%</div>
                     )}

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -369,12 +369,12 @@ const UnstakingCalculator: React.FC = () => {
                               stakingPoolForView.stakingPool.data.zilToTokenRate
                             ),
                             18
-                          )}
+                          )}{" "}
+                          ZIL
                         </>
                       ) : (
                         <div className="loading-blur "> 1Zil =~ 1zil</div>
                       )}
-                      ZIL
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
# Description

Rate now shows how much ZIL a single LST worth, same as when unstaking. 
<img width="977" alt="Screenshot 2025-03-07 at 15 52 49" src="https://github.com/user-attachments/assets/2198365d-ccc7-44c8-9614-eda61109b26c" />

# Testing

Looks fine when running against devnet locally.