### PR TITLE
APT-1877, APT-1878: Exchange rate precision and tx links

### DIFF
--- a/src/components/LastTransaction.tsx
+++ b/src/components/LastTransaction.tsx
@@ -1,26 +1,28 @@
 import { AppConfigStorage } from "@/contexts/appConfigStorage"
-import { StakingOperations } from "@/contexts/stakingOperations"
 import { formatAddress, getTxExplorerUrl } from "@/misc/formatting"
 import Link from "next/link"
 import React from "react"
 
-const LastTransaction: React.FC = () => {
+export interface LastTransactionProps {
+  txHash?: string
+}
+
+const LastTransaction: React.FC<LastTransactionProps> = ({ txHash }) => {
   const { appConfig } = AppConfigStorage.useContainer()
 
-  const { stakingCallTxHash } = StakingOperations.useContainer()
-  return stakingCallTxHash !== undefined ? (
+  return txHash !== undefined ? (
     <div className="text-center mb-3 info-label">
       <Link
         rel="noopener noreferrer"
         target="_blank"
-        href={getTxExplorerUrl(stakingCallTxHash, appConfig.chainId)}
+        href={getTxExplorerUrl(txHash, appConfig.chainId)}
         passHref={true}
         className="text-gray8"
       >
         Last transaction:{" "}
         <span className="text-white underline hover:text-aqua1 active:text-tealDark">
           {" "}
-          {formatAddress(stakingCallTxHash)}
+          {formatAddress(txHash)}
         </span>
       </Link>
     </div>

--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -6,13 +6,11 @@ import {
   formatPercentage,
   convertZilValueInToken,
   getHumanFormDuration,
-  formatUnitsToHumanReadable,
   convertTokenToZil,
+  formatUnitsWithMaxPrecision,
 } from "@/misc/formatting"
 import { formatUnits, parseEther } from "viem"
 import { StakingOperations } from "@/contexts/stakingOperations"
-import { AppConfigStorage } from "@/contexts/appConfigStorage"
-import Link from "next/link"
 import { StakingPoolType } from "@/misc/stakingPoolsConfig"
 import CustomWalletConnect from "./customWalletConnect"
 import { DateTime } from "luxon"
@@ -20,7 +18,6 @@ import LastTransaction from "./LastTransaction"
 
 const StakingCalculator: React.FC = () => {
   const inputRef = useRef<InputRef | null>(null)
-  const { appConfig } = AppConfigStorage.useContainer()
 
   const { isWalletConnected } = WalletConnector.useContainer()
 
@@ -360,7 +357,7 @@ const StakingCalculator: React.FC = () => {
               )}
             </div>
 
-            <LastTransaction />
+            <LastTransaction txHash={stakingCallTxHash} />
 
             <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 mt-2.5 lg:mt-4 4k:mt-6 border-t border-black2 lg:pb-10">
               <div className="flex flex-col lg:gap-2.5 gap-1 4k:gap-4 regular-base">
@@ -402,12 +399,13 @@ const StakingCalculator: React.FC = () => {
                               .tokenSymbol
                           }{" "}
                           =~
-                          {formatUnitsToHumanReadable(
+                          {formatUnitsWithMaxPrecision(
                             convertTokenToZil(
                               parseEther("1"),
                               stakingPoolForView.stakingPool.data.zilToTokenRate
                             ),
-                            18
+                            18,
+                            5
                           )}
                         </>{" "}
                         ZIL

--- a/src/components/stakingPoolDetailsView.tsx
+++ b/src/components/stakingPoolDetailsView.tsx
@@ -6,7 +6,7 @@ import {
   convertTokenToZil,
   formatPercentage,
   formatUnitsToHumanReadable,
-  getHumanFormDuration,
+  formatUnitsWithMaxPrecision,
 } from "@/misc/formatting"
 import { StakingPool, StakingPoolType } from "@/misc/stakingPoolsConfig"
 import {
@@ -201,15 +201,14 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
         "",
         <>
           1 {stakingPoolData.definition.tokenSymbol} = ~ <br />
-          {parseFloat(
-            formatUnits(
-              convertTokenToZil(
-                parseEther("1"),
-                stakingPoolData.data.zilToTokenRate
-              ),
-              18
-            )
-          ).toFixed(2)}{" "}
+          {formatUnitsWithMaxPrecision(
+            convertTokenToZil(
+              parseEther("1"),
+              stakingPoolData.data.zilToTokenRate
+            ),
+            18,
+            3
+          )}{" "}
           ZIL
         </>,
         ""

--- a/src/components/unstakingCalculator.tsx
+++ b/src/components/unstakingCalculator.tsx
@@ -6,8 +6,7 @@ import {
   convertTokenToZil,
   formatUnitsToHumanReadable,
   getHumanFormDuration,
-  getTxExplorerUrl,
-  formatAddress,
+  formatUnitsWithMaxPrecision,
 } from "@/misc/formatting"
 import { formatUnits, parseEther, parseUnits } from "viem"
 import { StakingOperations } from "@/contexts/stakingOperations"
@@ -16,14 +15,11 @@ import { StakingPoolType } from "@/misc/stakingPoolsConfig"
 import FastFadeScroll from "@/components/FastFadeScroll"
 import { WalletConnector } from "@/contexts/walletConnector"
 import CustomWalletConnect from "./customWalletConnect"
-import Link from "next/link"
-import { AppConfigStorage } from "@/contexts/appConfigStorage"
 import LastTransaction from "./LastTransaction"
 
 const UnstakingCalculator: React.FC = () => {
   const inputRef = useRef<InputRef | null>(null)
 
-  const { appConfig } = AppConfigStorage.useContainer()
   const { isWalletConnected } = WalletConnector.useContainer()
   const { stakingPoolForView } = StakingPoolsStorage.useContainer()
 
@@ -315,7 +311,7 @@ const UnstakingCalculator: React.FC = () => {
             )}
           </div>
 
-          <LastTransaction />
+          <LastTransaction txHash={unstakingCallTxHash} />
 
           <div className="flex justify-between pt-2.5 lg:pt-5 4k:pt-7 mt-2.5 lg:mt-4 4k:mt-6 border-t border-black2 lg:pb-10">
             <div className="flex flex-col lg:gap-2.5 gap-1 regular-base">
@@ -363,12 +359,13 @@ const UnstakingCalculator: React.FC = () => {
                               .tokenSymbol
                           }{" "}
                           =~
-                          {formatUnitsToHumanReadable(
+                          {formatUnitsWithMaxPrecision(
                             convertTokenToZil(
                               parseEther("1"),
                               stakingPoolForView.stakingPool.data.zilToTokenRate
                             ),
-                            18
+                            18,
+                            5
                           )}{" "}
                           ZIL
                         </>

--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -1,12 +1,9 @@
-import { AppConfigStorage } from "@/contexts/appConfigStorage"
 import { StakingOperations } from "@/contexts/stakingOperations"
 import { StakingPoolsStorage } from "@/contexts/stakingPoolsStorage"
 
 import {
-  formatAddress,
   formatUnitsToHumanReadable,
   getHumanFormDuration,
-  getTxExplorerUrl,
 } from "@/misc/formatting"
 import { StakingPool, StakingPoolType } from "@/misc/stakingPoolsConfig"
 import {
@@ -15,7 +12,6 @@ import {
 } from "@/misc/walletsConfig"
 import { Button, Tooltip } from "antd"
 import { DateTime } from "luxon"
-import Link from "next/link"
 import { formatUnits } from "viem"
 import LastTransaction from "./LastTransaction"
 
@@ -45,7 +41,6 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
     preparingStakeRewardTx,
   } = StakingOperations.useContainer()
 
-  const { appConfig } = AppConfigStorage.useContainer()
   const { getMinimalPoolStakingAmount } = StakingPoolsStorage.useContainer()
 
   const pendingUnstake = userUnstakingPoolData
@@ -67,7 +62,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
 
   return (
     <div className="h-full">
-      <LastTransaction />
+      <LastTransaction txHash={hashToShow} />
 
       {reward && (
         <div

--- a/src/misc/formatting.ts
+++ b/src/misc/formatting.ts
@@ -60,6 +60,12 @@ export function convertZilValueInToken(
   return `${(zilAmount * zilToTokenRate).toFixed(2)}`
 }
 
+/**
+ * returns @param value formatted to a string that is using the most appropriate unit
+ * e.g., 1,000,000 ZIL will be formatted as 1M ZIL
+ *
+ * @note this function is useful for displaying large values
+ */
 export function formatUnitsToHumanReadable(
   value: bigint,
   decimals: number
@@ -72,6 +78,22 @@ export function formatUnitsToHumanReadable(
   })
 
   return formatter.format(raw)
+}
+
+/**
+ * returns @param value formatted to a string with a maximum precision of @param maxPrecision
+ * trailing zeros are removed
+ *
+ * @note this function is useful for displaying small values
+ */
+export function formatUnitsWithMaxPrecision(
+  value: bigint,
+  decimals: number,
+  maxPrecision: number
+): string {
+  const raw = parseFloat(formatUnits(value, decimals))
+
+  return raw.toPrecision(maxPrecision).replace(/\.?0+$/, "")
 }
 
 export function getTxExplorerUrl(txHash: string, chainId: number) {

--- a/src/misc/stakingPoolsConfig.ts
+++ b/src/misc/stakingPoolsConfig.ts
@@ -260,7 +260,7 @@ export const stakingPoolsConfigForChainId: Record<
           apr: 0.135,
           commission: 0.1,
           votingPower: 0.3,
-          zilToTokenRate: 1.2,
+          zilToTokenRate: 0.156374848922222,
         },
         2000
       ),
@@ -285,7 +285,7 @@ export const stakingPoolsConfigForChainId: Record<
           apr: 0.21,
           commission: 0.011,
           votingPower: 0.5,
-          zilToTokenRate: 1.1,
+          zilToTokenRate: 0.7723232322,
         },
         1000
       ),
@@ -310,7 +310,7 @@ export const stakingPoolsConfigForChainId: Record<
           apr: 1.1,
           commission: 0.05,
           votingPower: 0.2,
-          zilToTokenRate: 1.3,
+          zilToTokenRate: 0.9392382873,
         },
         5000
       ),
@@ -335,7 +335,7 @@ export const stakingPoolsConfigForChainId: Record<
           apr: 0.13,
           commission: 0.01,
           votingPower: 0.01,
-          zilToTokenRate: 1,
+          zilToTokenRate: 1.5,
         },
         500
       ),
@@ -360,7 +360,7 @@ export const stakingPoolsConfigForChainId: Record<
           apr: 0.13,
           commission: 0.01,
           votingPower: 0.05,
-          zilToTokenRate: 1,
+          zilToTokenRate: 0.111112323232313,
         },
         100
       ),


### PR DESCRIPTION
# Description

1. Increases the precision on pool info to 3, and on unstaking/staking calculator to 5,
2. Fixes the LastTransaction so it links to correct tx instead of staking one.

# Testing

I've tested the changes with mocked wallets, exchange rate numbers now give more detailed information. The txs shown after the txs are sent are also now correct.