### PR TITLE
APT-1888: ZIL instead of token symbol used for `unstaked` pool info

### DIFF
--- a/src/components/stakingCalculator.tsx
+++ b/src/components/stakingCalculator.tsx
@@ -4,7 +4,7 @@ import { Button, Input, InputRef, Tooltip } from "antd"
 import { WalletConnector } from "@/contexts/walletConnector"
 import {
   formatPercentage,
-  convertZilValueInToken,
+  convertZilValueToToken,
   getHumanFormDuration,
   convertTokenToZil,
   formatUnitsWithMaxPrecision,
@@ -228,7 +228,7 @@ const StakingCalculator: React.FC = () => {
                           !isNaN(
                             stakingPoolForView.stakingPool.data.zilToTokenRate
                           )
-                            ? convertZilValueInToken(
+                            ? convertZilValueToToken(
                                 zilToStakeNumber,
                                 stakingPoolForView.stakingPool.data
                                   .zilToTokenRate

--- a/src/components/stakingPoolDetailsView.tsx
+++ b/src/components/stakingPoolDetailsView.tsx
@@ -354,20 +354,16 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
                     <>
                       <div>Amount of ZIL currently staked</div>
                       {isPoolLiquid() &&
-                        userStakingPoolData &&
-                        userStakingPoolData.stakingTokenAmount &&
+                        userStakingPoolData?.stakingTokenAmount &&
                         stakingPoolData.data != null && (
                           <div className="mt-1">
-                            {`                    
-                      ( ~
-                          ${formatUnitsToHumanReadable(
-                            convertTokenToZil(
-                              userStakingPoolData.stakingTokenAmount,
-                              stakingPoolData.data.zilToTokenRate
-                            ),
-                            18
-                          )} 
-                      ZIL )`}
+                            {`( ~ ${formatUnitsToHumanReadable(
+                              convertTokenToZil(
+                                userStakingPoolData.stakingTokenAmount,
+                                stakingPoolData.data.zilToTokenRate
+                              ),
+                              18
+                            )} ZIL )`}
                           </div>
                         )}
                     </>
@@ -375,32 +371,13 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
                   {colorInfoEntry(
                     "Unstaked ",
                     pendingUnstakesValue
-                      ? `${humanReadableStakingToken(
-                          pendingUnstakesValue
-                        )} ${stakingPoolData.definition.tokenSymbol}`
+                      ? `${humanReadableStakingToken(pendingUnstakesValue)} ZIL`
                       : "-",
                     <>
                       <div>
                         Amount of unstaked ZIL available after the unbonding
                         period
                       </div>
-                      {isPoolLiquid() &&
-                        userStakingPoolData &&
-                        pendingUnstakesValue &&
-                        stakingPoolData.data != null && (
-                          <div className="mt-1">
-                            {`                    
-                      ( ~
-                          ${formatUnitsToHumanReadable(
-                            convertTokenToZil(
-                              pendingUnstakesValue,
-                              stakingPoolData.data.zilToTokenRate
-                            ),
-                            18
-                          )} 
-                      ZIL )`}
-                          </div>
-                        )}
                     </>
                   )}
                   {colorInfoEntry(
@@ -474,7 +451,7 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
                         pendingUnstakesValue
                           ? `${humanReadableStakingToken(
                               pendingUnstakesValue
-                            )} ${stakingPoolData.definition.tokenSymbol}`
+                            )} ZIL`
                           : "-",
                         "Amount of unstaked ZIL available after the unbonding period"
                       )}
@@ -572,7 +549,7 @@ const StakingPoolDetailsView: React.FC<StakingPoolDetailsViewProps> = ({
                       pendingUnstakesValue
                         ? `${humanReadableStakingToken(
                             pendingUnstakesValue
-                          )} ${stakingPoolData.definition.tokenSymbol}`
+                          )} ZIL`
                         : "-",
                       "Amount of unstaked ZIL available after the unbonding period"
                     )}

--- a/src/misc/formatting.ts
+++ b/src/misc/formatting.ts
@@ -53,7 +53,7 @@ export function convertTokenToZil(
   return amount
 }
 
-export function convertZilValueInToken(
+export function convertZilValueToToken(
   zilAmount: number,
   zilToTokenRate: number
 ) {


### PR DESCRIPTION
# Description

The amount pending during the unbounding period reported by a contract is in ZIL. This PR fixes the info box and toolbox for it:
<img width="911" alt="Screenshot 2025-03-17 at 14 16 42" src="https://github.com/user-attachments/assets/1c88a77d-9d51-47b8-9580-51cda3c6f0d6" />

# Testing

Works fine when running locally.