### PR TITLE
APT-1891: Improved claims view

### DIFF
--- a/src/components/withdrawUnstakedZilPanel.tsx
+++ b/src/components/withdrawUnstakedZilPanel.tsx
@@ -262,7 +262,7 @@ const WithdrawZilPanel: React.FC<WithdrawZilPanelProps> = ({
 
       {!!otherPendingClaimsToShow && (
         <div className="mt-3 ">
-          <div className="info-label mb-3">other pending claims</div>
+          <div className="info-label mb-3">Other pending claims</div>
 
           {otherPendingClaimsToShow.map((claim, claimIdx) => (
             <div


### PR DESCRIPTION
# Description

* In case when there are multiple pending claims the UI looks like that (Mocked wallet 5, Ignite)
<img width="976" alt="Screenshot 2025-03-19 at 15 34 35" src="https://github.com/user-attachments/assets/7145951d-99ef-425d-976e-77ccf5282f70" />

* in case there are pending claims and available as well, the UI looks like that (Mocked wallet 6, Quantum)
<img width="1001" alt="Screenshot 2025-03-19 at 15 35 34" src="https://github.com/user-attachments/assets/2538b68d-0657-4185-a1c8-cf7e6a2a9ac9" />
