### PR TITLE
APT-1884: Wallet disconnection state handling fixed

### DIFF
--- a/src/contexts/stakingPoolsStorage.tsx
+++ b/src/contexts/stakingPoolsStorage.tsx
@@ -118,6 +118,8 @@ const useStakingPoolsStorage = () => {
   const reloadUserStakingPoolsData = () => {
     if (!walletAddress) {
       setUserStakingPoolsData([])
+      setUserUnstakesData([])
+      setUserNonLiquidPoolRewards([])
       return
     }
 

--- a/src/contexts/walletConnector.tsx
+++ b/src/contexts/walletConnector.tsx
@@ -61,7 +61,7 @@ const useWalletConnector = () => {
     connectedWalletType === ConnectedWalletType.MockWallet
       ? dummyWallet!.address
       : connectedWalletType === ConnectedWalletType.RealWallet
-        ? dummyWallet!.address
+        ? (walletAccount.address || null)
         : null
 
   const { data: zilBalanceData, refetch: refetchZilBalance } = useBalance({

--- a/src/contexts/walletConnector.tsx
+++ b/src/contexts/walletConnector.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { createContainer } from "./context"
 import { DummyWallet } from "@/misc/walletsConfig"
-import { useBalance, useWalletClient } from "wagmi"
+import { useAccount, useBalance } from "wagmi"
 import { Address } from "viem"
 
 export enum ConnectedWalletType {
@@ -44,23 +44,25 @@ const useWalletConnector = () => {
   /**
    * Rainbow wallet section
    */
-  const { data: walletClient } = useWalletClient()
+  const walletAccount = useAccount()
 
   /**
    * Wallet data
    */
 
-  const isWalletConnected = walletClient || isDummyWalletConnected
-  const connectedWalletType = walletClient
-    ? ConnectedWalletType.RealWallet
-    : isDummyWalletConnected
-      ? ConnectedWalletType.MockWallet
+  const isWalletConnected = walletAccount.isConnected || isDummyWalletConnected
+  const connectedWalletType = isDummyWalletConnected
+    ? ConnectedWalletType.MockWallet
+    : walletAccount.isConnected
+      ? ConnectedWalletType.RealWallet
       : ConnectedWalletType.None
-  const walletAddress = walletClient
-    ? walletClient.account.address
-    : isDummyWalletConnected
+
+  const walletAddress =
+    connectedWalletType === ConnectedWalletType.MockWallet
       ? dummyWallet!.address
-      : null
+      : connectedWalletType === ConnectedWalletType.RealWallet
+        ? dummyWallet!.address
+        : null
 
   const { data: zilBalanceData, refetch: refetchZilBalance } = useBalance({
     address: walletAddress ? (walletAddress as Address) : undefined,


### PR DESCRIPTION
# Description

- all state is cleaned on wallet address change
- now the app listens for the `account` change instead of the wallet. It may alleviate issues where, with some wallets, switching the account in-wallet doesn't switch the wallet in-app.

# Testing

Tested locally with mocked wallet.