### PR TITLE
Unbounding period is now calculated on the averaged block speed

### DIFF
--- a/src/misc/walletsConfig.ts
+++ b/src/misc/walletsConfig.ts
@@ -315,7 +315,8 @@ export async function getWalletStakingData(
 
 export async function getWalletUnstakingData(
   wallet: string,
-  chainId: number
+  chainId: number,
+  averageBlockTimeInSeconds: number
 ): Promise<UserUnstakingPoolData[]> {
   if (chainId === MOCK_CHAIN.id) {
     return new Promise((resolve) => {
@@ -371,7 +372,8 @@ export async function getWalletUnstakingData(
             ...uwd.blockNumberAndAmount.map((bna) => {
               const blocksRemaining = Number(bna[0] - currentBlockNumber)
 
-              const blocksRemainingInSeconds = blocksRemaining * 1 // seconds per block
+              const blocksRemainingInSeconds =
+                blocksRemaining * averageBlockTimeInSeconds
 
               return {
                 zilAmount: bna[1],

--- a/src/pages/api/config.ts
+++ b/src/pages/api/config.ts
@@ -1,3 +1,4 @@
+import { getViemClient } from "@/misc/chainConfig"
 import type { NextApiRequest, NextApiResponse } from "next"
 
 export type AppConfig = {
@@ -6,6 +7,7 @@ export type AppConfig = {
   intercomKey: string
   appUrl: string
   gtmId: string
+  averageBlockTime: number
 }
 
 function getStringFromEnv(name: string): string {
@@ -37,11 +39,59 @@ const config: AppConfig = {
   intercomKey: getStringFromEnv("ZQ2_STAKING_INTERCOM_KEY"),
   appUrl: getStringFromEnv("ZQ2_STAKING_APP_URL"),
   gtmId: getStringFromEnv("ZQ2_STAKING_GTM_ID"),
+  averageBlockTime: 1,
 }
 
-export default function handler(
+let cachedAverageBlockTime: number | null = null
+let lastCacheTime: number | null = null
+const CACHE_DURATION_MS = 60 * 60 * 1000 // 1 hour
+
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<AppConfig>
 ) {
-  res.status(200).json(config)
+  const now = Date.now()
+  if (
+    lastCacheTime &&
+    cachedAverageBlockTime &&
+    now - lastCacheTime < CACHE_DURATION_MS
+  ) {
+    return res.status(200).json({
+      ...config,
+      averageBlockTime: cachedAverageBlockTime,
+    })
+  }
+
+  const { getBlock } = getViemClient(config.chainId)
+  const blocksSpanToAverage = 10000n
+
+  try {
+    const latestBlock = await getBlock()
+    const { timestamp: latestBlockTimestamp, number: latestBlockNumber } =
+      latestBlock
+
+    const oldBlock = await getBlock({
+      blockNumber: latestBlockNumber - blocksSpanToAverage,
+    })
+    const { timestamp: oldBlockTimestamp } = oldBlock
+
+    const averageBlockTime =
+      (Number(latestBlockTimestamp) - Number(oldBlockTimestamp)) /
+      Number(blocksSpanToAverage)
+
+    cachedAverageBlockTime = averageBlockTime
+    lastCacheTime = now
+
+    res.status(200).json({
+      ...config,
+      averageBlockTime,
+    })
+  } catch (error) {
+    console.error("Failed to calculate average block time:", error)
+    // Fallback to the default or last known value if an error occurs
+    res.status(200).json({
+      ...config,
+      averageBlockTime: cachedAverageBlockTime ?? config.averageBlockTime,
+    })
+  }
 }

--- a/src/pages/watch.tsx
+++ b/src/pages/watch.tsx
@@ -64,7 +64,11 @@ const WatchPage = () => {
     try {
       const [stakingData, unstakingData, rewardsData] = await Promise.all([
         getWalletStakingData(searchAddress, appConfig.chainId),
-        getWalletUnstakingData(searchAddress, appConfig.chainId),
+        getWalletUnstakingData(
+          searchAddress,
+          appConfig.chainId,
+          appConfig.averageBlockTime
+        ),
         getWalletNonLiquidStakingPoolRewardData(
           searchAddress,
           appConfig.chainId


### PR DESCRIPTION
These changes introduce a centralized and dynamic calculation of the average block time for the Zilliqa network and integrate it throughout the application.

Previously, the average block time was either hardcoded or calculated in multiple places. Now, a new API endpoint (`/api/config`) is responsible for calculating the average block time based on the last 10,000 blocks and caching the result for one hour.

This calculated `averageBlockTime` is now part of the application's configuration and is used consistently in the following areas:
-   **Staking Pools**: When fetching staking pool data and user-specific staking information, the dynamic block time is used to provide more accurate estimations for unstaking periods.
-   **Wallet Data**: The functions for fetching a user's unstaking data (`getWalletUnstakingData`) now take the average block time as a parameter to accurately calculate when unstaked assets will become available.
-   **Watch Page**: The "Watch Address" feature now uses the new centralized block time to provide correct withdrawal availability information for any monitored address.

This refactoring improves the accuracy of time-sensitive features, like unstaking availability, by using a realistic and up-to-date average block time instead of a static value.