### PR TITLE
fix: DEVOPS-371 correct staking FAQ inaccuracies

### DIFF
--- a/src/components/faqModal.tsx
+++ b/src/components/faqModal.tsx
@@ -12,11 +12,13 @@ interface FaqModalProps {
 const FAQS = [
   {
     question: "What is the minimum ZIL balance required to delegate?",
-    answer: "The minimum required balance is 100 ZIL.",
+    answer:
+      "The minimum amount you can delegate is 100 ZIL per transaction. Note: after a partial unstake your remaining delegated balance may be lower than this.",
   },
   {
     question: "Which wallets are supported on the Zillion staking platform?",
-    answer: "You can use ZilPay, MetaMask, Rabby, and Ledger.",
+    answer:
+      "You can use Bearby Wallet, MetaMask, Rabby, Ledger, WalletConnect, Coinbase Wallet, Trust Wallet, and Rainbow.",
   },
   {
     question: "How long is a reward cycle?",
@@ -26,13 +28,13 @@ const FAQS = [
   {
     question: "How long does unstaking take?",
     answer:
-      "Unstaking takes 1,209,600 blocks, which is approximately 14 days, once the network returns to ~1 second block times.",
+      "Unstaking has an unbonding period of 461,680 blocks, roughly 6 days at current block times (about 5.3 days once the network is at ~1 second per block). Your ZIL can be withdrawn after this period.",
   },
   {
     question:
       "My transaction failed due to a low gas limit when claiming staking rewards. What should I do?",
     answer:
-      "Try increasing the gas limit to 200,000 and then attempt to claim rewards again.\nEnsure your account has at least 400 ZIL to cover the transaction with this gas setting. Do not change any other gas parameters.",
+      "Try increasing the gas limit to 200,000 and then attempt to claim rewards again.\nEnsure your account has at least 450 ZIL to cover the transaction with this gas setting. Do not change any other gas parameters.",
   },
   {
     question:
@@ -72,7 +74,7 @@ const FAQS = [
   {
     question: "Is there a staking tutorial?",
     answer:
-      "Yes. Please refer to the following tutorial: \nhttps://blog.zilliqa.com/how-to-restake-on-zilliqa-evm/",
+      "Yes. Please refer to the following tutorial: \nhttps://blog.zilliqa.com/how-to-stake-on-zilliqa-evm/",
   },
   {
     question: "Can we change delegators without unstaking first?",


### PR DESCRIPTION
## What

Audited all 10 entries in the staking FAQ (`src/components/faqModal.tsx`) and corrected the inaccurate ones. Each claim was verified against **on-chain getters / the official blog**, not the frontend constants (several of which are stale snapshots or display-only values).

## Changes

| FAQ | Before | After | Source of truth |
|-----|--------|-------|-----------------|
| Minimum balance | "minimum required balance is 100 ZIL" | "minimum to delegate is 100 ZIL per transaction" + partial-unstake caveat | on-chain `getMinDelegation()` gates the *deposit*, not the standing balance (a 50 ZIL position exists in r3to post partial-unstake) |
| Wallets | ZilPay, MetaMask, Rabby, Ledger | **Bearby Wallet** + all 8 connectors | `chainConfig.ts` configures 8 wallets; ZilPay rebranded to Bearby |
| Unstaking time | 1,209,600 blocks ≈ 14 days | 461,680 blocks ≈ 6 days (~5.3 @ 1s) | on-chain deposit `withdrawalPeriod()` + live block timing |
| Gas troubleshooting | 200,000 gas / 400 ZIL | 200,000 gas / **450 ZIL** | official blog. The `0x1e8480n` (2,000,000) constant is a UI fee-display value (`getGasCostInZil`), **not** a tx gas limit |
| Tutorial link | `…/how-to-restake-…` (HTTP 404) | `…/how-to-stake-…` (HTTP 200) | verified live |

Unchanged because verified accurate: reward cycle, contact, "why can't I unstake", liquid vs non-liquid, redelegation.

## Notes
- Strings only, no logic/rendering/schema changes. ESLint + Prettier clean.
- Follow-up (not in this PR): the UI's unbonding display is hardcoded `oneWeekInMinutes` (7 days) and never reads `withdrawalPeriod()`, so the in-app figure is ~1 day off; worth sourcing from chain separately.